### PR TITLE
Return better error messages

### DIFF
--- a/pkg/commands/apply.go
+++ b/pkg/commands/apply.go
@@ -15,14 +15,14 @@
 package commands
 
 import (
-	"github.com/google/ko/pkg/commands/options"
-	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"log"
 	"os"
 	"os/exec"
 
+	"github.com/google/ko/pkg/commands/options"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 )
 
 // addApply augments our CLI surface with apply.
@@ -62,6 +62,14 @@ func addApply(topLevel *cobra.Command) {
   cat config.yaml | ko apply -f -`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			builder, err := makeBuilder(do)
+			if err != nil {
+				log.Fatalf("error creating builder: %v", err)
+			}
+			publisher, err := makePublisher(no, lo, ta)
+			if err != nil {
+				log.Fatalf("error creating publisher: %v", err)
+			}
 			// Create a set of ko-specific flags to ignore when passing through
 			// kubectl global flags.
 			ignoreSet := make(map[string]struct{})
@@ -107,7 +115,7 @@ func addApply(topLevel *cobra.Command) {
 					stdin.Write([]byte("---\n"))
 				}
 				// Once primed kick things off.
-				resolveFilesToWriter(fo, no, lo, ta, do, stdin)
+				resolveFilesToWriter(builder, publisher, fo, stdin)
 			}()
 
 			// Run it.

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -21,12 +21,11 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/spf13/viper"
-
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -51,7 +50,7 @@ func getCreationTime() (*v1.Time, error) {
 
 	seconds, err := strconv.ParseInt(epoch, 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("the environment variable SOURCE_DATE_EPOCH is invalid. It's must be a number of seconds since January 1st 1970, 00:00 UTC, got %v", err)
+		return nil, fmt.Errorf("the environment variable SOURCE_DATE_EPOCH should be the number of seconds since January 1st 1970, 00:00 UTC, got: %v", err)
 	}
 	return &v1.Time{time.Unix(seconds, 0)}, nil
 }

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -15,14 +15,14 @@
 package commands
 
 import (
-	"github.com/google/ko/pkg/commands/options"
-	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"log"
 	"os"
 	"os/exec"
 
+	"github.com/google/ko/pkg/commands/options"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 )
 
 // addCreate augments our CLI surface with apply.
@@ -62,6 +62,14 @@ func addCreate(topLevel *cobra.Command) {
   cat config.yaml | ko create -f -`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			builder, err := makeBuilder(do)
+			if err != nil {
+				log.Fatalf("error creating builder: %v", err)
+			}
+			publisher, err := makePublisher(no, lo, ta)
+			if err != nil {
+				log.Fatalf("error creating publisher: %v", err)
+			}
 			// Create a set of ko-specific flags to ignore when passing through
 			// kubectl global flags.
 			ignoreSet := make(map[string]struct{})
@@ -107,7 +115,7 @@ func addCreate(topLevel *cobra.Command) {
 					stdin.Write([]byte("---\n"))
 				}
 				// Once primed kick things off.
-				resolveFilesToWriter(fo, no, lo, ta, do, stdin)
+				resolveFilesToWriter(builder, publisher, fo, stdin)
 			}()
 
 			// Run it.

--- a/pkg/commands/publish.go
+++ b/pkg/commands/publish.go
@@ -15,10 +15,11 @@
 package commands
 
 import (
+	"log"
+
 	"github.com/google/ko/pkg/commands/options"
 	"github.com/spf13/cobra"
 )
-
 
 // addPublish augments our CLI surface with publish.
 func addPublish(topLevel *cobra.Command) {
@@ -58,7 +59,17 @@ func addPublish(topLevel *cobra.Command) {
   ko publish --local github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah`,
 		Args: cobra.MinimumNArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
-			publishImages(args, no, lo, ta, do)
+			builder, err := makeBuilder(do)
+			if err != nil {
+				log.Fatalf("error creating builder: %v", err)
+			}
+			publisher, err := makePublisher(no, lo, ta)
+			if err != nil {
+				log.Fatalf("error creating publisher: %v", err)
+			}
+			if _, err := publishImages(args, publisher, builder); err != nil {
+				log.Fatalf("failed to publish images: %v", err)
+			}
 		},
 	}
 	options.AddLocalArg(publish, lo)

--- a/pkg/commands/resolve.go
+++ b/pkg/commands/resolve.go
@@ -15,9 +15,11 @@
 package commands
 
 import (
+	"log"
+	"os"
+
 	"github.com/google/ko/pkg/commands/options"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // addResolve augments our CLI surface with resolve.
@@ -55,7 +57,15 @@ func addResolve(topLevel *cobra.Command) {
   ko resolve --local -f config/`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			resolveFilesToWriter(fo, no, lo, ta, do, os.Stdout)
+			builder, err := makeBuilder(do)
+			if err != nil {
+				log.Fatalf("error creating builder: %v", err)
+			}
+			publisher, err := makePublisher(no, lo, ta)
+			if err != nil {
+				log.Fatalf("error creating publisher: %v", err)
+			}
+			resolveFilesToWriter(builder, publisher, fo, os.Stdout)
 		},
 	}
 	options.AddLocalArg(resolve, lo)

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -15,11 +15,11 @@
 package commands
 
 import (
-	"github.com/google/ko/pkg/commands/options"
 	"log"
 	"os"
 	"os/exec"
 
+	"github.com/google/ko/pkg/commands/options"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +45,18 @@ func addRun(topLevel *cobra.Command) {
   # This supports relative import paths as well.
   ko run foo --image=./cmd/baz`,
 		Run: func(cmd *cobra.Command, args []string) {
-			imgs := publishImages([]string{bo.Path}, no, lo, ta, do)
+			builder, err := makeBuilder(do)
+			if err != nil {
+				log.Fatalf("error creating builder: %v", err)
+			}
+			publisher, err := makePublisher(no, lo, ta)
+			if err != nil {
+				log.Fatalf("error creating publisher: %v", err)
+			}
+			imgs, err := publishImages([]string{bo.Path}, publisher, builder)
+			if err != nil {
+				log.Fatalf("failed to publish images: %v", err)
+			}
 
 			// There's only one, but this is the simple way to access the
 			// reference since the import path may have been qualified.


### PR DESCRIPTION
This hoists the publisher creation out of the loop for `ko publish` to
avoid needlessly resolving credentials multiple times.

This pulls the publisher creation outside of resolveFilesToWriter so we
can fail earlier if e.g. KO_DOCKER_REPO is unset, otherwise we start up
the kubectl goroutine and it would asynchronously fail with:

  error: no objects passed to apply