### PR TITLE
Print images to stdout as we publish them

### DIFF
--- a/pkg/commands/publish.go
+++ b/pkg/commands/publish.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/google/ko/pkg/commands/options"
@@ -67,8 +68,12 @@ func addPublish(topLevel *cobra.Command) {
 			if err != nil {
 				log.Fatalf("error creating publisher: %v", err)
 			}
-			if _, err := publishImages(args, publisher, builder); err != nil {
+			images, err := publishImages(args, publisher, builder)
+			if err != nil {
 				log.Fatalf("failed to publish images: %v", err)
+			}
+			for _, img := range images {
+				fmt.Println(img)
 			}
 		},
 	}


### PR DESCRIPTION
This will allow us to use it in a build script that isn't geared towards k8s, by naming packages we intend to publish directly, and then using the stdout to understand what images we published.

It's much easier than `... 2>&1 | grep -E '(Loaded|Published)' | rev | cut -d ' ' -f 1 | rev`