### PR TITLE
Allow skipping TLS verification while publishing image

### DIFF
--- a/pkg/commands/options/local.go
+++ b/pkg/commands/options/local.go
@@ -22,9 +22,12 @@ import (
 type LocalOptions struct {
 	// Local publishes images to a local docker daemon.
 	Local bool
+	InsecureRegistry bool
 }
 
 func AddLocalArg(cmd *cobra.Command, lo *LocalOptions) {
 	cmd.Flags().BoolVarP(&lo.Local, "local", "L", lo.Local,
 		"Whether to publish images to a local docker daemon vs. a registry.")
+	cmd.Flags().BoolVar(&lo.InsecureRegistry, "insecure-registry",  lo.InsecureRegistry,
+		"Whether to skip TLS verification on the registry")
 }

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -99,7 +99,8 @@ func makePublisher(no *options.NameOptions, lo *options.LocalOptions, ta *option
 		return publish.NewDefault(repoName,
 			publish.WithAuthFromKeychain(authn.DefaultKeychain),
 			publish.WithNamer(namer),
-			publish.WithTags(ta.Tags))
+			publish.WithTags(ta.Tags),
+			publish.Insecure(lo.InsecureRegistry))
 	}()
 	if err != nil {
 		return nil, err

--- a/pkg/publish/default.go
+++ b/pkg/publish/default.go
@@ -33,6 +33,7 @@ type defalt struct {
 	auth  authn.Authenticator
 	namer Namer
 	tags  []string
+	insecure bool
 }
 
 // Option is a functional option for NewDefault.
@@ -44,6 +45,7 @@ type defaultOpener struct {
 	auth  authn.Authenticator
 	namer Namer
 	tags  []string
+	insecure bool
 }
 
 // Namer is a function from a supported import path to the portion of the resulting
@@ -62,11 +64,12 @@ var defaultTags = []string{"latest"}
 
 func (do *defaultOpener) Open() (Interface, error) {
 	return &defalt{
-		base:  do.base,
-		t:     do.t,
-		auth:  do.auth,
-		namer: do.namer,
-		tags:  do.tags,
+		base:     do.base,
+		t:        do.t,
+		auth:     do.auth,
+		namer:    do.namer,
+		tags:     do.tags,
+		insecure: do.insecure,
 	}, nil
 }
 
@@ -95,7 +98,12 @@ func (d *defalt) Publish(img v1.Image, s string) (name.Reference, error) {
 	s = strings.ToLower(s)
 
 	for _, tagName := range d.tags {
-		tag, err := name.NewTag(fmt.Sprintf("%s/%s:%s", d.base, d.namer(s), tagName))
+
+		var os []name.Option
+		if d.insecure {
+			os = []name.Option{name.Insecure}
+		}
+		tag, err := name.NewTag(fmt.Sprintf("%s/%s:%s", d.base, d.namer(s), tagName), os...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/publish/options.go
+++ b/pkg/publish/options.go
@@ -80,3 +80,10 @@ func WithTags(tags []string) Option {
 		return nil
 	}
 }
+
+func Insecure(b bool) Option {
+	return func(i *defaultOpener) error {
+		i.insecure = b
+		return nil
+	}
+}


### PR DESCRIPTION
Why this is necessary: when using a local docker registry, users may not
want to support https, or there may be other troubles not allowing
verifiable TLS support.

This commit adds this functionality by adding an `--insecure-registry`
flag.

@jonjohnsonjr 

Fixes #64