### PR TITLE
Add permissions to the kodata directory.

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -299,6 +299,10 @@ func (g *gobuild) tarKoData(importpath string) (*bytes.Buffer, error) {
 			return tw.WriteHeader(&tar.Header{
 				Name:     kodataRoot,
 				Typeflag: tar.TypeDir,
+				// Use a fixed Mode, so that this isn't sensitive to the directory and umask
+				// under which it was created. Additionally, windows can only set 0222,
+				// 0444, or 0666, none of which are executable.
+				Mode: 0555,
 			})
 		}
 		if err != nil {

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -255,7 +255,7 @@ func TestGoBuild(t *testing.T) {
 	t.Run("check app layer contents", func(t *testing.T) {
 		expectedHash := v1.Hash{
 			Algorithm: "sha256",
-			Hex:       "63b6e090921b79b61e7f5fba44d2ea0f81215d9abac3d005dda7cb9a1f8a025d",
+			Hex:       "4379f30a6c6f66221c3c54dddd378fcfa5a7304a6655ff783b102069c0f943ab",
 		}
 		appLayer := ls[baseLayers]
 


### PR DESCRIPTION
I suspect that this may be a source of problems reading kodata with nonroot,
but it is probably worth doing either way.