### PR TITLE
Allow a port to be specified in KO_DOCKER_REPO.

### DIFF
--- a/vendor/github.com/google/go-containerregistry/pkg/name/repository.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/name/repository.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	defaultNamespace = "library"
-	repositoryChars  = "abcdefghijklmnopqrstuvwxyz0123456789_-./"
+	repositoryChars  = "abcdefghijklmnopqrstuvwxyz0123456789_-./:"
 	regRepoDelimiter = "/"
 )
 


### PR DESCRIPTION
This allows repo names such as 'localhost:5000' to be used.