### PR TITLE
Allow plain registries as KO_DOCKER_REPO

### DIFF
--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -93,9 +93,10 @@ func makePublisher(no *options.NameOptions, lo *options.LocalOptions, ta *option
 		if repoName == "" {
 			return nil, errors.New("KO_DOCKER_REPO environment variable is unset")
 		}
-		_, err := name.NewRepository(repoName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse environment variable KO_DOCKER_REPO=%q as repository: %v", repoName, err)
+		if _, err := name.NewRegistry(repoName); err != nil {
+			if _, err := name.NewRepository(repoName); err != nil {
+				return nil, fmt.Errorf("failed to parse environment variable KO_DOCKER_REPO=%q as repository: %v", repoName, err)
+			}
 		}
 
 		return publish.NewDefault(repoName,

--- a/pkg/publish/options.go
+++ b/pkg/publish/options.go
@@ -48,11 +48,16 @@ func WithAuthFromKeychain(keys authn.Keychain) Option {
 		// means that docker.io/mattmoor actually gets interpreted as
 		// docker.io/library/mattmoor, which gets tricky when we start
 		// appending things to it in the publisher.
-		repo, err := name.NewRepository(i.base)
+		reg, err := name.NewRegistry(i.base)
 		if err != nil {
-			return err
+			// Workaround for localhost:5000 as KO_DOCKER_REPO.
+			repo, err := name.NewRepository(i.base)
+			if err != nil {
+				return err
+			}
+			reg = repo.Registry
 		}
-		auth, err := keys.Resolve(repo.Registry)
+		auth, err := keys.Resolve(reg)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This allows you to use e.g. localhost:5000 as KO_DOCKER_REPO.

Fixes #93.