### PR TITLE
Support writing built images in OCI layout format to a file with the --oci-layout-path flag.

### DIFF
--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -24,6 +24,7 @@ import (
 type BuildOptions struct {
 	ConcurrentBuilds     int
 	DisableOptimizations bool
+	OCILayoutPath    string
 }
 
 func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
@@ -31,4 +32,5 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"The maximum number of concurrent builds")
 	cmd.Flags().BoolVar(&bo.DisableOptimizations, "disable-optimizations", bo.DisableOptimizations,
 		"Disable optimizations when building Go code. Useful when you want to interactively debug the created container.")
+	cmd.Flags().StringVarP(&bo.OCILayoutPath, "oci-layout-path", "", "", "Path to save the OCI image spec of the built images")
 }

--- a/pkg/commands/publish.go
+++ b/pkg/commands/publish.go
@@ -68,7 +68,7 @@ func addPublish(topLevel *cobra.Command) {
 			if err != nil {
 				log.Fatalf("error creating publisher: %v", err)
 			}
-			images, err := publishImages(args, publisher, builder)
+			images, err := publishImages(args, publisher, builder, bo.OCILayoutPath)
 			if err != nil {
 				log.Fatalf("failed to publish images: %v", err)
 			}

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -53,7 +53,7 @@ func addRun(topLevel *cobra.Command) {
 			if err != nil {
 				log.Fatalf("error creating publisher: %v", err)
 			}
-			imgs, err := publishImages([]string{po.Path}, publisher, builder)
+			imgs, err := publishImages([]string{po.Path}, publisher, builder, bo.OCILayoutPath)
 			if err != nil {
 				log.Fatalf("failed to publish images: %v", err)
 			}


### PR DESCRIPTION
This allows images built by ko to be used in Tekton. https://github.com/tektoncd/pipeline/blob/master/docs/resources.md#image-resource