### PR TITLE
Ignore null YAML documents when using a label selector.

### DIFF
--- a/pkg/commands/resolver_test.go
+++ b/pkg/commands/resolver_test.go
@@ -16,6 +16,7 @@ package commands
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"testing"
@@ -98,6 +99,36 @@ func TestResolveMultiDocumentYAMLs(t *testing.T) {
 
 	if diff := cmp.Diff(expectedStructured, outStructured, cmpopts.EquateEmpty()); diff != "" {
 		t.Errorf("resolveFile(%v); (-want +got) = %v", string(inputYAML), diff)
+	}
+}
+
+func TestResolveMultiDocumentYAMLsWithSelector(t *testing.T) {
+	passesSelector := `apiVersion: something/v1
+kind: Foo
+metadata:
+  labels:
+    qux: baz
+`
+	failsSelector := `apiVersion: other/v2
+kind: Bar
+`
+	// Note that this ends in '---', so it in ends in a final null YAML document.
+	inputYAML := []byte(fmt.Sprintf("%s---\n%s---", passesSelector, failsSelector))
+	base := mustRepository("gcr.io/multi-pass")
+
+	outputYAML, err := resolveFile(
+		yamlToTmpFile(t, inputYAML),
+		testBuilder,
+		kotesting.NewFixedPublish(base, testHashes),
+		&options.SelectorOptions{
+			Selector: "qux=baz",
+		},
+		&options.StrictOptions{})
+	if err != nil {
+		t.Fatalf("ImageReferences(%v) = %v", string(inputYAML), err)
+	}
+	if diff := cmp.Diff(passesSelector, string(outputYAML)); diff != "" {
+		t.Errorf("resolveFile (-want +got) = %v", diff)
 	}
 }
 

--- a/pkg/resolve/selector.go
+++ b/pkg/resolve/selector.go
@@ -47,6 +47,11 @@ func MatchesSelector(doc *yaml.Node, selector labels.Selector) (bool, error) {
 }
 
 func docKind(doc *yaml.Node) (string, error) {
+	// Null nodes will fail the check below, so simply ignore them.
+	if doc.Tag == "!!null" {
+		return "", nil
+	}
+
 	it := FromNode(doc).
 		Filter(Intersect(
 			WithKind(yaml.MappingNode),

--- a/pkg/resolve/selector_test.go
+++ b/pkg/resolve/selector_test.go
@@ -139,6 +139,11 @@ func TestMatchesSelector(t *testing.T) {
 		input:    podList,
 		selector: labels.Nothing(),
 		matches:  false,
+	}, {
+		desc: "null node",
+		input: "!!null",
+		selector: labels.Everything(),
+		matches: false,
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
Resolving a YAML that ends in an empty YAML node.
```shell
go run ./cmd/ko resolve -l foo=bar -f - <<END
apiVersion: v1
kind: A
metadata:
  labels:
    foo: bar
---
END
```
Before this change:
```
error processing import paths in "-": error evaluating selector: yaml doesn't represent a k8s object
exit status 1
```

After this change:
```
apiVersion: v1
kind: A
metadata:
  labels:
    foo: bar

---

```