### PR TITLE
Add entrypoint to PATH

### DIFF
--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -336,7 +337,24 @@ func TestGoBuild(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Error("Didn't find expected file in tarball.")
+			t.Error("Didn't find KO_DATA_PATH.")
+		}
+	})
+
+	// Check that PATH contains the produced binary.
+	t.Run("check PATH env var", func(t *testing.T) {
+		cfg, err := img.ConfigFile()
+		if err != nil {
+			t.Errorf("ConfigFile() = %v", err)
+		}
+		found := false
+		for _, entry := range cfg.Config.Env {
+			if strings.HasPrefix(entry, "PATH=") && strings.Contains(entry, "/ko-app/test") {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("Didn't find entrypoint in PATH.")
 		}
 	})
 


### PR DESCRIPTION
This makes it easier to invoke the binary when using a debug container.
E.g. you could invoke `ko` instead of `/ko-app/ko`.