### PR TITLE
Reorder parsing KO_DOCKER_REPO to get proper credentials

### DIFF
--- a/pkg/publish/options.go
+++ b/pkg/publish/options.go
@@ -48,16 +48,16 @@ func WithAuthFromKeychain(keys authn.Keychain) Option {
 		// means that docker.io/mattmoor actually gets interpreted as
 		// docker.io/library/mattmoor, which gets tricky when we start
 		// appending things to it in the publisher.
-		reg, err := name.NewRegistry(i.base)
+		repo, err := name.NewRepository(i.base)
 		if err != nil {
 			// Workaround for localhost:5000 as KO_DOCKER_REPO.
-			repo, err := name.NewRepository(i.base)
+			reg, err := name.NewRegistry(i.base)
 			if err != nil {
 				return err
 			}
-			reg = repo.Registry
+			repo = name.Repository{Registry: reg}
 		}
-		auth, err := keys.Resolve(reg)
+		auth, err := keys.Resolve(repo.Registry)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #93

With this change we support also pointing to default registry (without prefix).
Eg. KO_DOCKER_REPO=myuser