### PR TITLE
Add kubectl Check for ko delete

### DIFF
--- a/pkg/commands/apply.go
+++ b/pkg/commands/apply.go
@@ -64,6 +64,11 @@ func addApply(topLevel *cobra.Command) {
   cat config.yaml | ko apply -f -`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			if !isKubectlAvailable() {
+				log.Print("error: kubectl is not available. kubectl must be installed to use ko apply.")
+				return
+			}
+
 			builder, err := makeBuilder(bo)
 			if err != nil {
 				log.Fatalf("error creating builder: %v", err)

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -15,6 +15,8 @@
 package commands
 
 import (
+	"os/exec"
+
 	"github.com/spf13/cobra"
 )
 
@@ -30,4 +32,12 @@ func AddKubeCommands(topLevel *cobra.Command) {
 	addPublish(topLevel)
 	addRun(topLevel)
 	addCompletion(topLevel)
+}
+
+// check if kubectl is installed
+func isKubectlAvailable() bool {
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		return false
+	}
+	return true
 }

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -64,6 +64,11 @@ func addCreate(topLevel *cobra.Command) {
   cat config.yaml | ko create -f -`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			if !isKubectlAvailable() {
+				log.Print("error: kubectl is not available. kubectl must be installed to use ko create.")
+				return
+			}
+
 			builder, err := makeBuilder(bo)
 			if err != nil {
 				log.Fatalf("error creating builder: %v", err)

--- a/pkg/commands/delete.go
+++ b/pkg/commands/delete.go
@@ -15,10 +15,11 @@
 package commands
 
 import (
-	"github.com/spf13/cobra"
 	"log"
 	"os"
 	"os/exec"
+
+	"github.com/spf13/cobra"
 )
 
 // runCmd is suitable for use with cobra.Command's Run field.
@@ -28,6 +29,11 @@ type runCmd func(*cobra.Command, []string)
 // through to a binary named command.
 func passthru(command string) runCmd {
 	return func(_ *cobra.Command, _ []string) {
+		if !isKubectlAvailable() {
+			log.Print("error: kubectl is not available. kubectl must be installed to use ko delete.")
+			return
+		}
+
 		// Start building a command line invocation by passing
 		// through our arguments to command's CLI.
 		cmd := exec.Command(command, os.Args[1:]...)


### PR DESCRIPTION
This pull request adds an error message in case `kubectl` is not installed. I'm assuming most users of `ko` will have `kubectl` installed, but it's nice to have a clear message in the edge case when it's not available. 