### PR TITLE
Fix: Add directory containing binary to PATH

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -451,7 +451,7 @@ func (gb *gobuild) Build(ctx context.Context, s string) (v1.Image, error) {
 
 	cfg = cfg.DeepCopy()
 	cfg.Config.Entrypoint = []string{appPath}
-	updatePath(cfg, appPath)
+	updatePath(cfg)
 	cfg.Config.Env = append(cfg.Config.Env, "KO_DATA_PATH="+kodataRoot)
 	cfg.Author = "github.com/google/ko"
 
@@ -467,9 +467,9 @@ func (gb *gobuild) Build(ctx context.Context, s string) (v1.Image, error) {
 	return image, nil
 }
 
-// Append appPath to the PATH environment variable, if it exists. Otherwise,
-// set the PATH environment variable to appPath.
-func updatePath(cf *v1.ConfigFile, appPath string) {
+// Append appDir to the PATH environment variable, if it exists. Otherwise,
+// set the PATH environment variable to appDir.
+func updatePath(cf *v1.ConfigFile) {
 	for i, env := range cf.Config.Env {
 		parts := strings.SplitN(env, "=", 2)
 		if len(parts) != 2 {
@@ -478,12 +478,12 @@ func updatePath(cf *v1.ConfigFile, appPath string) {
 		}
 		key, value := parts[0], parts[1]
 		if key == "PATH" {
-			value = fmt.Sprintf("%s:%s", value, appPath)
+			value = fmt.Sprintf("%s:%s", value, appDir)
 			cf.Config.Env[i] = "PATH=" + value
 			return
 		}
 	}
 
 	// If we get here, we never saw PATH.
-	cf.Config.Env = append(cf.Config.Env, "PATH="+appPath)
+	cf.Config.Env = append(cf.Config.Env, "PATH="+appDir)
 }

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -341,16 +341,22 @@ func TestGoBuild(t *testing.T) {
 		}
 	})
 
-	// Check that PATH contains the produced binary.
+	// Check that PATH contains the directory of the produced binary.
 	t.Run("check PATH env var", func(t *testing.T) {
 		cfg, err := img.ConfigFile()
 		if err != nil {
 			t.Errorf("ConfigFile() = %v", err)
 		}
 		found := false
-		for _, entry := range cfg.Config.Env {
-			if strings.HasPrefix(entry, "PATH=") && strings.Contains(entry, "/ko-app/test") {
-				found = true
+		for _, envVar := range cfg.Config.Env {
+			if strings.HasPrefix(envVar, "PATH=") {
+				pathValue := strings.TrimPrefix(envVar, "PATH=")
+				pathEntries := strings.Split(pathValue, ":")
+				for _, pathEntry := range pathEntries {
+					if pathEntry == appDir {
+						found = true
+					}
+				}
 			}
 		}
 		if !found {


### PR DESCRIPTION
Fixes the PATH environment variable so it contains the directory
containing the binary (i.e., /ko-app) instead of the binary itself
(e.g., /ko-app/ko).

See #114.