### PR TITLE
Set AutomaticEnv for viper

### DIFF
--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -77,6 +77,8 @@ func init() {
 	// If omitted, use this base image.
 	viper.SetDefault("defaultBaseImage", "gcr.io/distroless/static:latest")
 	viper.SetConfigName(".ko") // .yaml is implicit
+	viper.SetEnvPrefix("KO")
+	viper.AutomaticEnv()
 
 	if override := os.Getenv("KO_CONFIG_PATH"); override != "" {
 		viper.AddConfigPath(override)


### PR DESCRIPTION
This allows viper configuration to be set using environment variables
instead of just with a config file.

Fixes #130 

```
$ KO_DEFAULTBASEIMAGE=ubuntu ko publish ./cmd/ko
2020/02/06 13:31:51 Using base ubuntu for github.com/google/ko/cmd/ko
```

```
$ KO_BASEIMAGEOVERRIDES='{"github.com/google/ko/cmd/ko":"ubuntu"}' ko publish ./cmd/ko
2020/02/06 13:30:08 Using base ubuntu for github.com/google/ko/cmd/ko
```