### PR TITLE
Deterministically fail ko {apply, create}

### DIFF
--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -22,6 +23,7 @@ import (
 	"github.com/google/ko/pkg/commands/options"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"golang.org/x/sync/errgroup"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -110,7 +112,12 @@ func addCreate(topLevel *cobra.Command) {
 				log.Fatalf("error piping to 'kubectl create': %v", err)
 			}
 
-			go func() {
+			// Cancel on signals.
+			ctx := createCancellableContext()
+
+			// Make sure builds are cancelled if kubectl create fails.
+			g, ctx := errgroup.WithContext(ctx)
+			g.Go(func() error {
 				// kubectl buffers data before starting to create it, which
 				// can lead to resources being created more slowly than desired.
 				// In the case of --watch, it can lead to resources not being
@@ -122,13 +129,19 @@ func addCreate(topLevel *cobra.Command) {
 					stdin.Write([]byte("---\n"))
 				}
 				// Once primed kick things off.
-				ctx := createCancellableContext()
-				resolveFilesToWriter(ctx, builder, publisher, fo, so, sto, stdin)
-			}()
+				return resolveFilesToWriter(ctx, builder, publisher, fo, so, sto, stdin)
+			})
 
-			// Run it.
-			if err := kubectlCmd.Run(); err != nil {
-				log.Fatalf("error executing 'kubectl create': %v", err)
+			g.Go(func() error {
+				// Run it.
+				if err := kubectlCmd.Run(); err != nil {
+					return fmt.Errorf("error executing 'kubectl create': %v", err)
+				}
+				return nil
+			})
+
+			if err := g.Wait(); err != nil {
+				log.Fatal(err)
 			}
 		},
 	}

--- a/pkg/commands/resolve.go
+++ b/pkg/commands/resolve.go
@@ -67,7 +67,9 @@ func addResolve(topLevel *cobra.Command) {
 				log.Fatalf("error creating publisher: %v", err)
 			}
 			ctx := createCancellableContext()
-			resolveFilesToWriter(ctx, builder, publisher, fo, so, sto, os.Stdout)
+			if err := resolveFilesToWriter(ctx, builder, publisher, fo, so, sto, os.Stdout); err != nil {
+				log.Fatal(err)
+			}
 		},
 	}
 	options.AddLocalArg(resolve, lo)


### PR DESCRIPTION
Fixes #84 

When resolving files, we would just log.Fatal if we encountered an
error. This seems to be racy and causes ko to exit with a 0 error code
when it shouldn't. To fix this, we synchronize the builder goroutines
with the kubectl go routine and exit with an error if either of them
failed.

This fix also happened to fix a goroutine leak. If the kubectl goroutine
failed, we never properly cancelled the builds, which would happily
conitnue compiling packages and consuming resources.