### PR TITLE
Viper keys are case insensitive.

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -124,7 +124,6 @@ func NewGo(options ...Option) (Interface, error) {
 func (g *gobuild) IsSupportedReference(s string) bool {
 	p, err := g.importPackage(s)
 	if err != nil {
-		log.Printf("ERROR: %v", err)
 		return false
 	}
 	return p.IsCommand()

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -124,6 +124,7 @@ func NewGo(options ...Option) (Interface, error) {
 func (g *gobuild) IsSupportedReference(s string) bool {
 	p, err := g.importPackage(s)
 	if err != nil {
+		log.Printf("ERROR: %v", err)
 		return false
 	}
 	return p.IsCommand()

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -37,7 +38,13 @@ var (
 )
 
 func getBaseImage(s string) (v1.Image, error) {
-	ref, ok := baseImageOverrides[s]
+	// Viper configuration file keys are case insensitive, and are
+	// returned as all lowercase.  This means that import paths with
+	// uppercase must be normalized for matching here, e.g.
+	//    github.com/GoogleCloudPlatform/foo/cmd/bar
+	// comes through as:
+	//    github.com/googlecloudplatform/foo/cmd/bar
+	ref, ok := baseImageOverrides[strings.ToLower(s)]
 	if !ok {
 		ref = defaultBaseImage
 	}


### PR DESCRIPTION
This fixes an issue where import paths with uppercase (github.com/GoogleCloudPlatform :eyes:) were being canonicalized by Viper to all lowercase and the baseImageOverrides in `.ko.yaml` were failing to properly identify the base image.

I hit this in: https://github.com/tektoncd/pipeline/pull/2435 trying to opt some of the GCP images out of `:nonroot`.

This also adds some logging to a place where I see a lot of folks have issues with `ko` where we swallow an error.  I hit it experimenting with variants on the `ko publish` import path, and added the logging to debug.