### PR TITLE
[modules] support references that point to modules in the vendored folder

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -461,7 +461,7 @@ func (gb *gobuild) Build(ctx context.Context, s string) (v1.Image, error) {
 	}
 
 	// Do the build into a temporary file.
-	file, err := gb.build(ctx, pkg.ImportPath, platform, gb.disableOptimizations)
+	file, err := gb.build(ctx, pkg.Dir, platform, gb.disableOptimizations)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -461,7 +461,7 @@ func (gb *gobuild) Build(ctx context.Context, s string) (v1.Image, error) {
 	}
 
 	// Do the build into a temporary file.
-	file, err := gb.build(ctx, pkg.Dir, platform, gb.disableOptimizations)
+	file, err := gb.build(ctx, pkg.ImportPath, platform, gb.disableOptimizations)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -151,7 +151,7 @@ func writeTempFile(_ context.Context, s string, _ v1.Platform, _ bool) (string, 
 		return "", err
 	}
 	defer file.Close()
-	if _, err := file.WriteString(filepath.ToSlash(s)); err != nil {
+	if _, err := file.WriteString(filepath.Base(s)); err != nil {
 		return "", err
 	}
 	return file.Name(), nil
@@ -197,7 +197,7 @@ func TestGoBuildNoKoData(t *testing.T) {
 	t.Run("check determinism", func(t *testing.T) {
 		expectedHash := v1.Hash{
 			Algorithm: "sha256",
-			Hex:       "fb82c95fc73eaf26d0b18b1bc2d23ee32059e46806a83a313e738aac4d039492",
+			Hex:       "090bf776407c6aea609b6db5f1e1cf9b23dd755e21d5a7155f652c1f0ad29be8",
 		}
 		appLayer := ls[baseLayers+1]
 
@@ -277,7 +277,7 @@ func TestGoBuild(t *testing.T) {
 	t.Run("check determinism", func(t *testing.T) {
 		expectedHash := v1.Hash{
 			Algorithm: "sha256",
-			Hex:       "4c7f97dda30576670c3a8967424f7dea023030bb3df74fc4bd10329bcb266fc2",
+			Hex:       "aa059d9574c7ad90f32869ece7f1539f6b6eea617f03f3b6a9997fe22a8ead90",
 		}
 		appLayer := ls[baseLayers+1]
 


### PR DESCRIPTION

This should unblock using references like:

   `knative.dev/serving/vendor/github.com/tsenart/vegeta`
  `./vendor/github.com/tsenart/vegeta`