### PR TITLE
Some small nits around the codebase to make linters happy.

### DIFF
--- a/cmd/ko/test/main.go
+++ b/cmd/ko/test/main.go
@@ -28,12 +28,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error reading %q: %v", file, err)
 	}
-	log.Printf(string(bytes))
+	log.Print(string(bytes))
 
 	file = filepath.Join(dp, "refs/heads/master")
 	bytes, err = ioutil.ReadFile(file)
 	if err != nil {
 		log.Fatalf("Error reading %q: %v", file, err)
 	}
-	log.Printf(string(bytes))
+	log.Print(string(bytes))
 }

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -151,7 +151,7 @@ func TestGoBuildNoKoData(t *testing.T) {
 	}
 	importpath := "github.com/google/ko"
 
-	creationTime := v1.Time{time.Unix(5000, 0)}
+	creationTime := v1.Time{Time: time.Unix(5000, 0)}
 	ng, err := NewGo(
 		WithCreationTime(creationTime),
 		WithBaseImages(func(string) (v1.Image, error) { return base, nil }),
@@ -231,7 +231,7 @@ func TestGoBuild(t *testing.T) {
 	}
 	importpath := "github.com/google/ko"
 
-	creationTime := v1.Time{time.Unix(5000, 0)}
+	creationTime := v1.Time{Time: time.Unix(5000, 0)}
 	ng, err := NewGo(
 		WithCreationTime(creationTime),
 		WithBaseImages(func(string) (v1.Image, error) { return base, nil }),

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -64,7 +64,7 @@ func getCreationTime() (*v1.Time, error) {
 	if err != nil {
 		return nil, fmt.Errorf("the environment variable SOURCE_DATE_EPOCH should be the number of seconds since January 1st 1970, 00:00 UTC, got: %v", err)
 	}
-	return &v1.Time{time.Unix(seconds, 0)}, nil
+	return &v1.Time{Time: time.Unix(seconds, 0)}, nil
 }
 
 func createCancellableContext() context.Context {

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -261,7 +261,7 @@ func TestStrict(t *testing.T) {
 		}
 	}
 	base := mustRepository("gcr.io/multi-pass")
-	doc := strToYAML(t, string(buf.Bytes()))
+	doc := strToYAML(t, buf.String())
 
 	err := ImageReferences(context.Background(), []*yaml.Node{doc}, true, testBuilder, kotesting.NewFixedPublish(base, testHashes))
 	if err != nil {
@@ -280,7 +280,7 @@ func TestNoStrictKoPrefixRemains(t *testing.T) {
 	}
 
 	base := mustRepository("gcr.io/multi-pass")
-	doc := strToYAML(t, string(buf.Bytes()))
+	doc := strToYAML(t, buf.String())
 
 	noMatchBuilder := kotesting.NewFixedBuild(nil)
 


### PR DESCRIPTION
Well, as per title. Properly key struct literals, don't use formatting functions where not necessary and convert from buffer to string directly.