### PR TITLE
Fix k8s.io/cli-runtime "require"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71
 	gotest.tools/v3 v3.0.2 // indirect
 	k8s.io/apimachinery v0.18.8
-	k8s.io/cli-runtime v0.17.1
+	k8s.io/cli-runtime v0.18.8
 	sigs.k8s.io/kind v0.8.1
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -350,7 +350,7 @@ k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
-# k8s.io/cli-runtime v0.17.1 => k8s.io/cli-runtime v0.18.8
+# k8s.io/cli-runtime v0.18.8 => k8s.io/cli-runtime v0.18.8
 ## explicit
 k8s.io/cli-runtime/pkg/genericclioptions
 k8s.io/cli-runtime/pkg/kustomize


### PR DESCRIPTION
The "require" is behind the version in "replace", and since cli-runtime references the package mentioned in the errors we are seeing, rule this out as a source!