### PR TITLE
Add a handful of files to trigger more analyses.

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,21 @@
+coverage:
+  # Commit status https://docs.codecov.io/docs/commit-status are used
+  # to block PR based on coverage threshold.
+  status:
+    project:
+      default:
+        target: 80
+        threshold: 1%
+    patch:
+      # Disable the coverage threshold of the patch, so that PRs are
+      # only failing because of overall project coverage threshold.
+      # See https://docs.codecov.io/docs/commit-status#disabling-a-status.
+      default: false
+ignore:
+  - "**/zz_generated*.go" # Ignore generated files.
+  - "**/*.pb.go" # Ignore proto-generated files.
+  - "hack"
+  - "pkg/client"
+  - "test"
+  - "third_party"
+  - "vendor"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,41 @@
+run:
+  timeout: 5m
+
+  build-tags:
+    - e2e
+    - performance
+    - probe
+    - preupgrade
+    - postupgrade
+    - postdowngrade
+    - istio
+
+  skip-dirs:
+    - pkg/client
+
+  skip-files:
+    - ".pb.go$"
+
+linters:
+  enable:
+    - asciicheck
+    - gosec
+    - prealloc
+    - stylecheck
+    - unconvert
+    - unparam
+  disable:
+    - errcheck
+
+issues:
+  exclude-rules:
+    - path: test # Excludes /test, *_test.go etc.
+      linters:
+        - gosec
+        - unparam
+
+    # Allow source and sink receivers in conversion code for clarity.
+    - path: _conversion\.go
+      text: "ST1016:"
+      linters:
+        - stylecheck

--- a/hack/boilerplate/boilerplate.go.txt
+++ b/hack/boilerplate/boilerplate.go.txt
@@ -1,0 +1,15 @@
+/*
+Copyright 2020 Google LLC All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/

--- a/hack/boilerplate/boilerplate.sh.txt
+++ b/hack/boilerplate/boilerplate.sh.txt
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Copyright 2020 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
`.codecov.yaml` - Enable codecov.io coverage reports
`.golangci.yaml` - Enable the enumerated checks in golangci-lint
`boilerplate.*.txt` - Enable file header boilerplate checks for these extensions