### PR TITLE
Fix base image resolution

### DIFF
--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -58,7 +58,7 @@ func getBaseImage(platform string) build.GetBase {
 		//    github.com/GoogleCloudPlatform/foo/cmd/bar
 		// comes through as:
 		//    github.com/googlecloudplatform/foo/cmd/bar
-		ref, ok := baseImageOverrides[strings.ToLower(s)]
+		ref, ok := baseImageOverrides[strings.ToLower(strings.TrimPrefix(s, build.StrictScheme))]
 		if !ok {
 			ref = defaultBaseImage
 		}


### PR DESCRIPTION
I noticed that my `.ko.yaml` was being ignored because it was looking for `ko://` prefixed things.

I also tried this with `ko publish` three ways: `ko://`-prefixed, non-`ko://` prefixed, and relative path, and all picked up the appropriate base.