### PR TITLE
Revive progress and warning logs

### DIFF
--- a/cmd/ko/main.go
+++ b/cmd/ko/main.go
@@ -16,13 +16,18 @@ package main
 
 import (
 	"log"
+	"os"
 
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/ko/pkg/commands"
 
 	"github.com/spf13/cobra"
 )
 
 func main() {
+	logs.Warn.SetOutput(os.Stderr)
+	logs.Progress.SetOutput(os.Stderr)
+
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   "ko",

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -52,13 +52,14 @@ func getBaseImage(platform string) build.GetBase {
 	}
 
 	return func(s string) (build.Result, error) {
+		s = strings.TrimPrefix(s, build.StrictScheme)
 		// Viper configuration file keys are case insensitive, and are
 		// returned as all lowercase.  This means that import paths with
 		// uppercase must be normalized for matching here, e.g.
 		//    github.com/GoogleCloudPlatform/foo/cmd/bar
 		// comes through as:
 		//    github.com/googlecloudplatform/foo/cmd/bar
-		ref, ok := baseImageOverrides[strings.ToLower(strings.TrimPrefix(s, build.StrictScheme))]
+		ref, ok := baseImageOverrides[strings.ToLower(s)]
 		if !ok {
 			ref = defaultBaseImage
 		}


### PR DESCRIPTION
These got dropped when we pulled in:
https://github.com/google/go-containerregistry/pull/481

Which doesn't log by default, and requires opting in.

Before:
```
$ ko publish -P ./cmd/ko/
2020/09/25 11:23:47 Using base gcr.io/distroless/static:nonroot for ko://github.com/google/ko/cmd/ko
2020/09/25 11:23:48 Building github.com/google/ko/cmd/ko for linux/amd64
2020/09/25 11:23:56 Publishing gcr.io/jonjohnson-test/ko/github.com/google/ko/cmd/ko:latest
2020/09/25 11:24:10 Published gcr.io/jonjohnson-test/ko/github.com/google/ko/cmd/ko@sha256:088f55132ffdea808364a21f9973b9e463c03b9bc1f8a33a80bbaa89a359f456
gcr.io/jonjohnson-test/ko/github.com/google/ko/cmd/ko@sha256:088f55132ffdea808364a21f9973b9e463c03b9bc1f8a33a80bbaa89a359f456
```

After:
```
$ ko publish -P ./cmd/ko/
2020/09/25 11:23:08 Using base gcr.io/distroless/static:nonroot for github.com/google/ko/cmd/ko
2020/09/25 11:23:10 Building github.com/google/ko/cmd/ko for linux/amd64
2020/09/25 11:23:17 Publishing gcr.io/jonjohnson-test/ko/github.com/google/ko/cmd/ko:latest
2020/09/25 11:23:17 existing blob: sha256:7438552acdc56e8eda4401142955d4860f25be2af6348aef4c0ddd0f4eeaa0af
2020/09/25 11:23:17 existing blob: sha256:3c2cba919283a210665e480bcbf943eaaf4ed87a83f02e81bb286b8bdead0e75
2020/09/25 11:23:17 existing blob: sha256:72164b581b02b1eb297b403bcc8fc1bfa245cb52e103a3a525a0835a58ff58e2
2020/09/25 11:23:17 existing blob: sha256:fa712d40dbb2c65903bbd9996c3cdb22e5a07eb18dce44c425335463c8b5daf1
2020/09/25 11:23:17 existing blob: sha256:4000adbbc3eb1099e3a263c418f7c1d7def1fa2de0ae00ba48245cda9389c823
2020/09/25 11:23:18 gcr.io/jonjohnson-test/ko/github.com/google/ko/cmd/ko:latest: digest: sha256:73de099249bf3269c7dd1fbf951b3f5d793e7ae0d1115fcd068802d0e897312e size: 910
2020/09/25 11:23:18 Published gcr.io/jonjohnson-test/ko/github.com/google/ko/cmd/ko@sha256:73de099249bf3269c7dd1fbf951b3f5d793e7ae0d1115fcd068802d0e897312e
gcr.io/jonjohnson-test/ko/github.com/google/ko/cmd/ko@sha256:73de099249bf3269c7dd1fbf951b3f5d793e7ae0d1115fcd068802d0e897312e
```

Also fixes `Using base gcr.io/distroless/static:nonroot for ko://github.com/google/ko/cmd/ko`, since we're fixing logs anyway.