### PR TITLE
(Fix #191) Add required go version to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 `ko` can be installed and upgraded by running:
 
+**Note**: Golang version `1.12.0` or higher is required.
+
 ```shell
 GO111MODULE=on go get github.com/google/ko/cmd/ko
 ```


### PR DESCRIPTION
KO gives an error for the wrong go versions. The error is not very verbose.It is diffcult to decipher the logs of the error given. As a developer, adding a note to the installation process would prevent me from stumbling onto this issue.