### PR TITLE
Remove docs for Strict Mode and --strict flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,19 +267,6 @@ of convenience for cleaning up resources created through `ko apply`.
 `ko version` prints version of ko. For not released binaries it will print hash
 of latest commit in current git tree.
 
-### Strict Mode
-
-It can be difficult for `ko` to determine whether a string in a YAML file is
-intended to be an import path, due to typos, non-`package main` packages, and
-conflicts between import paths and common strings (e.g., a package whose import
-path is `busybox`). To solve this, `ko` supports "Strict Mode".
-
-When referencing an import path in the YAML file, prefix the string with the
-string `ko://` (e.g., `ko://github.com/my/repo/cmd/foo`). Then, when calling
-`ko apply` or `ko resolve`, pass `--strict`. If a string with the `ko://` prefix
-is not determined to be a valid import path, the command will fail, rather than
-passing it through to the resolved YAML.
-
 ## With `minikube`
 
 You can use `ko` with `minikube` via a Docker Registry, but this involves

--- a/pkg/commands/apply.go
+++ b/pkg/commands/apply.go
@@ -147,7 +147,6 @@ func addApply(topLevel *cobra.Command) {
 	options.AddPublishArg(apply, po)
 	options.AddFileArg(apply, fo)
 	options.AddSelectorArg(apply, so)
-	options.AddStrictArg(apply, sto)
 	options.AddBuildOptions(apply, bo)
 
 	// Collect the ko-specific apply flags before registering the kubectl global

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -147,7 +147,6 @@ func addCreate(topLevel *cobra.Command) {
 	options.AddPublishArg(create, po)
 	options.AddFileArg(create, fo)
 	options.AddSelectorArg(create, so)
-	options.AddStrictArg(create, sto)
 	options.AddBuildOptions(create, bo)
 
 	// Collect the ko-specific apply flags before registering the kubectl global

--- a/pkg/commands/options/strict.go
+++ b/pkg/commands/options/strict.go
@@ -14,16 +14,7 @@
 
 package options
 
-import (
-	"github.com/spf13/cobra"
-)
-
 // StrictOptions holds options to require strict references.
 type StrictOptions struct {
 	Strict bool
-}
-
-func AddStrictArg(cmd *cobra.Command, so *StrictOptions) {
-	cmd.Flags().BoolVarP(&so.Strict, "strict", "", so.Strict,
-		`If true, require package references to be explicitly prefixed with "ko://"`)
 }

--- a/pkg/commands/resolve.go
+++ b/pkg/commands/resolve.go
@@ -74,7 +74,6 @@ func addResolve(topLevel *cobra.Command) {
 	options.AddPublishArg(resolve, po)
 	options.AddFileArg(resolve, fo)
 	options.AddSelectorArg(resolve, so)
-	options.AddStrictArg(resolve, sto)
 	options.AddBuildOptions(resolve, bo)
 	topLevel.AddCommand(resolve)
 }


### PR DESCRIPTION
#162 removed support for `--strict` without removing docs describing the flag, or the now-meaningless flag.

