### PR TITLE
Fix things pointed out by golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,21 +1,6 @@
 run:
   timeout: 5m
 
-  build-tags:
-    - e2e
-    - performance
-    - probe
-    - preupgrade
-    - postupgrade
-    - postdowngrade
-    - istio
-
-  skip-dirs:
-    - pkg/client
-
-  skip-files:
-    - ".pb.go$"
-
 linters:
   enable:
     - asciicheck
@@ -32,10 +17,3 @@ issues:
     - path: test # Excludes /test, *_test.go etc.
       linters:
         - gosec
-        - unparam
-
-    # Allow source and sink receivers in conversion code for clarity.
-    - path: _conversion\.go
-      text: "ST1016:"
-      linters:
-        - stylecheck

--- a/cmd/ko/test/main.go
+++ b/cmd/ko/test/main.go
@@ -37,10 +37,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error reading %q: %v", file, err)
 	}
-	log.Printf(string(bytes))
+	log.Print(string(bytes))
 
 	// Cause the pod to "hang" to allow us to check for a readiness state.
-	sigs := make(chan os.Signal)
+	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGTERM)
 	<-sigs
 }

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -425,7 +425,7 @@ func (g *gobuild) tarKoData(ref reference) (*bytes.Buffer, error) {
 	return buf, walkRecursive(tw, root, kodataRoot)
 }
 
-func (gb *gobuild) buildOne(ctx context.Context, s string, base v1.Image) (v1.Image, error) {
+func (g *gobuild) buildOne(ctx context.Context, s string, base v1.Image) (v1.Image, error) {
 	ref := newRef(s)
 
 	cf, err := base.ConfigFile()
@@ -438,7 +438,7 @@ func (gb *gobuild) buildOne(ctx context.Context, s string, base v1.Image) (v1.Im
 	}
 
 	// Do the build into a temporary file.
-	file, err := gb.build(ctx, ref.Path(), platform, gb.disableOptimizations)
+	file, err := g.build(ctx, ref.Path(), platform, g.disableOptimizations)
 	if err != nil {
 		return nil, err
 	}
@@ -446,7 +446,7 @@ func (gb *gobuild) buildOne(ctx context.Context, s string, base v1.Image) (v1.Im
 
 	var layers []mutate.Addendum
 	// Create a layer from the kodata directory under this import path.
-	dataLayerBuf, err := gb.tarKoData(ref)
+	dataLayerBuf, err := g.tarKoData(ref)
 	if err != nil {
 		return nil, err
 	}
@@ -514,8 +514,8 @@ func (gb *gobuild) buildOne(ctx context.Context, s string, base v1.Image) (v1.Im
 	}
 
 	empty := v1.Time{}
-	if gb.creationTime != empty {
-		return mutate.CreatedAt(image, gb.creationTime)
+	if g.creationTime != empty {
+		return mutate.CreatedAt(image, g.creationTime)
 	}
 	return image, nil
 }
@@ -542,9 +542,9 @@ func updatePath(cf *v1.ConfigFile) {
 }
 
 // Build implements build.Interface
-func (gb *gobuild) Build(ctx context.Context, s string) (Result, error) {
+func (g *gobuild) Build(ctx context.Context, s string) (Result, error) {
 	// Determine the appropriate base image for this import path.
-	base, err := gb.getBase(s)
+	base, err := g.getBase(s)
 	if err != nil {
 		return nil, err
 	}
@@ -561,20 +561,20 @@ func (gb *gobuild) Build(ctx context.Context, s string) (Result, error) {
 		if !ok {
 			return nil, fmt.Errorf("failed to interpret base as index: %v", base)
 		}
-		return gb.buildAll(ctx, s, base)
+		return g.buildAll(ctx, s, base)
 	case types.OCIManifestSchema1, types.DockerManifestSchema2:
 		base, ok := base.(v1.Image)
 		if !ok {
 			return nil, fmt.Errorf("failed to interpret base as image: %v", base)
 		}
-		return gb.buildOne(ctx, s, base)
+		return g.buildOne(ctx, s, base)
 	default:
 		return nil, fmt.Errorf("base image media type: %s", mt)
 	}
 }
 
 // TODO(#192): Do these in parallel?
-func (gb *gobuild) buildAll(ctx context.Context, s string, base v1.ImageIndex) (v1.ImageIndex, error) {
+func (g *gobuild) buildAll(ctx context.Context, s string, base v1.ImageIndex) (v1.ImageIndex, error) {
 	im, err := base.IndexManifest()
 	if err != nil {
 		return nil, err
@@ -592,7 +592,7 @@ func (gb *gobuild) buildAll(ctx context.Context, s string, base v1.ImageIndex) (
 		if err != nil {
 			return nil, err
 		}
-		img, err := gb.buildOne(ctx, s, base)
+		img, err := g.buildOne(ctx, s, base)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -397,7 +397,7 @@ func TestGoBuild(t *testing.T) {
 	}
 	importpath := "github.com/google/ko"
 
-	creationTime := v1.Time{time.Unix(5000, 0)}
+	creationTime := v1.Time{Time: time.Unix(5000, 0)}
 	ng, err := NewGo(
 		WithCreationTime(creationTime),
 		WithBaseImages(func(string) (Result, error) { return base, nil }),
@@ -451,7 +451,7 @@ func TestGoBuildIndex(t *testing.T) {
 	}
 	importpath := "github.com/google/ko"
 
-	creationTime := v1.Time{time.Unix(5000, 0)}
+	creationTime := v1.Time{Time: time.Unix(5000, 0)}
 	ng, err := NewGo(
 		WithCreationTime(creationTime),
 		WithBaseImages(func(string) (Result, error) { return base, nil }),
@@ -521,7 +521,7 @@ func TestNestedIndex(t *testing.T) {
 
 	nestedBase := mutate.AppendManifests(empty.Index, mutate.IndexAddendum{Add: base})
 
-	creationTime := v1.Time{time.Unix(5000, 0)}
+	creationTime := v1.Time{Time: time.Unix(5000, 0)}
 	ng, err := NewGo(
 		WithCreationTime(creationTime),
 		WithBaseImages(func(string) (Result, error) { return nestedBase, nil }),

--- a/pkg/commands/options/publish.go
+++ b/pkg/commands/options/publish.go
@@ -15,7 +15,7 @@
 package options
 
 import (
-	"crypto/md5"
+	"crypto/md5" //nolint: gosec // No strong cryptography needed.
 	"encoding/hex"
 	"path/filepath"
 
@@ -64,7 +64,7 @@ func AddPublishArg(cmd *cobra.Command, po *PublishOptions) {
 }
 
 func packageWithMD5(importpath string) string {
-	hasher := md5.New()
+	hasher := md5.New() //nolint: gosec // No strong cryptography needed.
 	hasher.Write([]byte(importpath))
 	return filepath.Base(importpath) + "-" + hex.EncodeToString(hasher.Sum(nil))
 }

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// provided by govvv in compile-time
+// Version is provided by govvv at compile-time
 var Version string
 
 // addVersion augments our CLI surface with version.

--- a/pkg/resolve/selector.go
+++ b/pkg/resolve/selector.go
@@ -17,7 +17,7 @@ package resolve
 import (
 	"errors"
 
-	. "github.com/dprotaso/go-yit"
+	. "github.com/dprotaso/go-yit" //nolint: stylecheck // Allow this dot import.
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/labels"
 )


### PR DESCRIPTION
This fixes the linting issues as pointed out by `golangci-lint`. Also reduces its config a bit as most of it isn't necessary here.