### PR TITLE
Set GOARM based on platform.variant

### DIFF
--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -540,3 +540,70 @@ func TestNestedIndex(t *testing.T) {
 		t.Errorf("Build() expected unexpected mediaType error, got: %s", err)
 	}
 }
+
+func TestGoarm(t *testing.T) {
+	// From golang@sha256:1ba0da74b20aad52b091877b0e0ece503c563f39e37aa6b0e46777c4d820a2ae
+	// and made up invalid cases.
+	for _, tc := range []struct {
+		platform v1.Platform
+		variant  string
+		err      bool
+	}{{
+		platform: v1.Platform{
+			Architecture: "arm",
+			OS:           "linux",
+			Variant:      "vnot-a-number",
+		},
+		err: true,
+	}, {
+		platform: v1.Platform{
+			Architecture: "arm",
+			OS:           "linux",
+			Variant:      "wrong-prefix",
+		},
+		err: true,
+	}, {
+		platform: v1.Platform{
+			Architecture: "arm64",
+			OS:           "linux",
+			Variant:      "v3",
+		},
+		variant: "",
+	}, {
+		platform: v1.Platform{
+			Architecture: "arm",
+			OS:           "linux",
+			Variant:      "v5",
+		},
+		variant: "5",
+	}, {
+		platform: v1.Platform{
+			Architecture: "arm",
+			OS:           "linux",
+			Variant:      "v7",
+		},
+		variant: "7",
+	}, {
+		platform: v1.Platform{
+			Architecture: "arm64",
+			OS:           "linux",
+			Variant:      "v8",
+		},
+		variant: "7",
+	},
+	} {
+		variant, err := getGoarm(tc.platform)
+		if tc.err {
+			if err == nil {
+				t.Errorf("getGoarm(%v) expected err", tc.platform)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("getGoarm failed for %v: %v", tc.platform, err)
+		}
+		if got, want := variant, tc.variant; got != want {
+			t.Errorf("wrong variant for %v: want %q got %q", tc.platform, want, got)
+		}
+	}
+}


### PR DESCRIPTION
This relies on some hard-coded knowledge of the go compiler, which is
unfortunate, so we will have to update this if things change.

Fixes https://github.com/google/ko/issues/235

```
$ crane manifest $(ko publish --platform=all -B ./cmd/ko) | jq .
2020/11/04 11:23:19 Using base golang for github.com/google/ko/cmd/ko
2020/11/04 11:23:19 No matching credentials were found, falling back on anonymous
2020/11/04 11:23:20 Building github.com/google/ko/cmd/ko for linux/amd64
2020/11/04 11:23:26 Building github.com/google/ko/cmd/ko for linux/arm
2020/11/04 11:24:38 Building github.com/google/ko/cmd/ko for linux/arm
2020/11/04 11:25:56 Building github.com/google/ko/cmd/ko for linux/arm64
2020/11/04 11:27:10 Building github.com/google/ko/cmd/ko for linux/386
2020/11/04 11:28:31 Building github.com/google/ko/cmd/ko for linux/mips64le
2020/11/04 11:29:55 Building github.com/google/ko/cmd/ko for linux/ppc64le
2020/11/04 11:31:21 Building github.com/google/ko/cmd/ko for linux/s390x
2020/11/04 11:32:40 Building github.com/google/ko/cmd/ko for windows/amd64
2020/11/04 11:34:04 Building github.com/google/ko/cmd/ko for windows/amd64
2020/11/04 11:34:11 Publishing gcr.io/jonjohnson-test/ko/ko:latest
2020/11/04 11:34:11 existing manifest: sha256:6f777bfc2417d9282b981aef39049a45e3a97049106fbfc9265dc5245fa3ec89
2020/11/04 11:34:12 existing blob: sha256:72164b581b02b1eb297b403bcc8fc1bfa245cb52e103a3a525a0835a58ff58e2
2020/11/04 11:34:12 existing blob: sha256:7a4c9d08d8ee472a70c0c7dffb75c54e692061eb72c3b0ddf55669727b29c7d8
2020/11/04 11:34:12 existing blob: sha256:d80349201e0e0bc9a1bdeb726d9339525972e3d76225d15b87f72414b0aec137
2020/11/04 11:34:12 existing blob: sha256:8af3c3d8d3991106266aa0fdac96aee7d1846d7873190f68820c7e917dbaa428
2020/11/04 11:34:12 existing blob: sha256:04da375e247f9c460ec111fc1fbefc3457a452fefe7e3f255165c837fbcc3400
2020/11/04 11:34:12 existing blob: sha256:b4513ea2e624c1315c50d01e77da41c690aab244542fb1424a914e8881e0fefc
2020/11/04 11:34:12 existing blob: sha256:b196b0bc956fafcab3622d17314250431b67b84c0d5938dfff3759e02ba97efa
2020/11/04 11:34:12 existing blob: sha256:a1c03b81470f92875dbe52bf0054ebf042576e7f28903477ad4abe4c4f9734ce
2020/11/04 11:34:13 pushed blob: sha256:8d49562dbaf4363b5d2d7c4ae8e9ff992c5227930624526803764c82cd9a0ea5
2020/11/04 11:34:15 pushed blob: sha256:14900bcb6baeafeb4363c288eda6d44669f52fab63d61f4d95071bf9b6806651
2020/11/04 11:34:16 gcr.io/jonjohnson-test/ko/ko@sha256:225dcfc690d5d677e7ac71b9261cf8d7c82606c551ce14c87bb9b4f32b826610: digest: sha256:225dcfc690d5d677e7ac71b9261cf8d7c82606c551ce14c87bb9b4f32b826610 size: 1737
2020/11/04 11:34:17 existing blob: sha256:72164b581b02b1eb297b403bcc8fc1bfa245cb52e103a3a525a0835a58ff58e2
2020/11/04 11:34:17 existing blob: sha256:5c0fdcca2cbb5e316a288f39c8c2006f45544568ea04623c036e0b1faa066bbe
2020/11/04 11:34:17 existing blob: sha256:8216e147de931a74896e75f60d0a331dd1438bc1ae4b2d4c29c8017548e8dcbd
2020/11/04 11:34:17 existing blob: sha256:a8771f21930318372521f18351173851be5905de53c0c8a17cb705232d3f5eaa
2020/11/04 11:34:17 existing blob: sha256:baf6642121709e17d1419901978da7d29b673d5f936e42ec3241b7d7157e9541
2020/11/04 11:34:17 existing blob: sha256:6ffd240154ca95f066ad0371221039621dc56a5e9aabb2792bed7377281c0b82
2020/11/04 11:34:17 existing blob: sha256:a4709bf55c028577981f5f1d6b33c909312be45bd3cbf108c14640cc4af7143e
2020/11/04 11:34:17 existing blob: sha256:5754411f60ee27fceb92d6380a748ae6d60239063cfa8165419be0ebf9de5834
2020/11/04 11:34:18 pushed blob: sha256:7b1bafca1d0111ab4bfdd273bf5fdd1e4f8a497824ec978bd51b27bb55542565
2020/11/04 11:34:20 pushed blob: sha256:75fd71fb32482cfe78b28ccbcf655ff2422677b08594bc615548b7f5aff8649a
2020/11/04 11:34:20 gcr.io/jonjohnson-test/ko/ko@sha256:5d0e62c2b235271442d9eca9c851914bed3e0ba9c1298b517b270e34d80dcf6f: digest: sha256:5d0e62c2b235271442d9eca9c851914bed3e0ba9c1298b517b270e34d80dcf6f size: 1736
2020/11/04 11:34:20 existing blob: sha256:72164b581b02b1eb297b403bcc8fc1bfa245cb52e103a3a525a0835a58ff58e2
2020/11/04 11:34:21 existing blob: sha256:04aacb10cb67f5fa248646a0ac9f40af5a6d3b0dbef65505bb7766bed6bf4885
2020/11/04 11:34:21 existing blob: sha256:ff74fb95e95674d2f0c26f446a2cb7c0ee055d78182a9d61e1578c64c171f2b4
2020/11/04 11:34:21 existing blob: sha256:5e93de5b9fb0600346e952c63496fc16e8428829b5b213f0f7d661bee8f93a0e
2020/11/04 11:34:21 existing blob: sha256:e1215201ecb4985557d36d9b1bd58e9ca5d858f86e7d3839fd37b43d41af0f4d
2020/11/04 11:34:21 existing blob: sha256:136d6e4f4b17bdbefbe60820da5f5711a26d31c075dc69bcaf9b077d7d29262d
2020/11/04 11:34:21 existing blob: sha256:2198039b51ff463f1fedadd4078efe6e85fe165622f21aef869fd7c265ef7103
2020/11/04 11:34:21 existing blob: sha256:28db65b8364fc73072a0d5b51199cc9c6b108b4229d92e784b92ae67898dd0bd
2020/11/04 11:34:22 pushed blob: sha256:fa72ef183a53773ed6a50f499dcf7ee2f6e6d5b26d5d39dc955009ec321b4df6
2020/11/04 11:34:23 pushed blob: sha256:85135fb04f7b1c3b2cc1b0df4812cfa0c7c937336c045ae8b33455947536e07f
2020/11/04 11:34:24 gcr.io/jonjohnson-test/ko/ko@sha256:bf35a275d966f45a4a57ab31cf016b16fef49e544edd603547a5193a4dc91e1b: digest: sha256:bf35a275d966f45a4a57ab31cf016b16fef49e544edd603547a5193a4dc91e1b size: 1736
2020/11/04 11:34:25 existing blob: sha256:72164b581b02b1eb297b403bcc8fc1bfa245cb52e103a3a525a0835a58ff58e2
2020/11/04 11:34:25 existing blob: sha256:63785be044bb8d2e10e90138f54d46ca10cdf3c488a506f016e20e3616b3ed47
2020/11/04 11:34:25 existing blob: sha256:70642f7883120399f94e6ebeaf462f650791e043356533691f94187b38407d54
2020/11/04 11:34:25 existing blob: sha256:04cfdeb65fa7b61136583b4eb3201ddcc0d43a347eb1b84d4414c344558c5613
2020/11/04 11:34:25 existing blob: sha256:2f7a218c61768debfbd306af73aba7ce33e177373f9074a3655c5289d599706b
2020/11/04 11:34:25 existing blob: sha256:f4c66bb1532454b3436fcb390052e08e606d67758d6573cc469b5f8ef2b0282c
2020/11/04 11:34:25 existing blob: sha256:c303ed7c76e74ddfd5fc798c4922c89902a340db03b34bdaeb1974366f3c46a1
2020/11/04 11:34:25 existing blob: sha256:9c8877040857a379f0cff57156f02fb981f93659e41e5e5c58760bd4ae80475c
2020/11/04 11:34:26 pushed blob: sha256:a22f4425020d0500087bf3f43ab5ccddb254492c4b2adc7e192d82e9bf835de0
2020/11/04 11:34:28 pushed blob: sha256:e9cedfdb5f5162d80fdff7dddeb8215ad99526521f827ea52bf18dd2843ac8bc
2020/11/04 11:34:28 gcr.io/jonjohnson-test/ko/ko@sha256:a5ee0f4a4d800ea0384618e6fc0ea6c9efb46b3434e7496c059e8685a8923006: digest: sha256:a5ee0f4a4d800ea0384618e6fc0ea6c9efb46b3434e7496c059e8685a8923006 size: 1738
2020/11/04 11:34:29 existing blob: sha256:72164b581b02b1eb297b403bcc8fc1bfa245cb52e103a3a525a0835a58ff58e2
2020/11/04 11:34:29 existing blob: sha256:5d59dde81c0fb34075db3f3333fe270df5548321a70da94193c507ae578bded2
2020/11/04 11:34:29 existing blob: sha256:54f0d53e5adbca273451bf395721917941847d9808e2dfb23b3b21a8bd3d30f4
2020/11/04 11:34:29 existing blob: sha256:563cb7b9f3c30fcbb19d79fcfce967a57d35fde75fab6e71be156974ed0c6f5e
2020/11/04 11:34:29 existing blob: sha256:cdb7ecbbb9a11d82d8b68ac910eb4d6a536ce23ee4172e81a7166d6b6f22535c
2020/11/04 11:34:29 existing blob: sha256:ac9fa0fe8b7cfee668c6e3bde93142a152fe555cc0ec5cfae9d36585ba3c8620
2020/11/04 11:34:29 existing blob: sha256:4c82d5acaa60d5b36fc634c6b79ed00bee8d08c39b78242c5fe5938754739ab7
2020/11/04 11:34:29 existing blob: sha256:9fd0710976c57d8d2e5a2f13cccd726cca5d8b0f607868465c8cffbdcf2d3940
2020/11/04 11:34:30 pushed blob: sha256:de3af8b20bddca43874b163ca3be85fb7e7a52ffbafb0841b084c9399916e226
2020/11/04 11:34:32 pushed blob: sha256:257deeeffc0ed4b5e52852e8dcaa03cbf803ae74322381e2381aa4cf4b5e8870
2020/11/04 11:34:33 gcr.io/jonjohnson-test/ko/ko@sha256:20614018734dd0ccf48a31a05a5ae1c40d09192ec54b1b11da3148fa3ea94628: digest: sha256:20614018734dd0ccf48a31a05a5ae1c40d09192ec54b1b11da3148fa3ea94628 size: 1738
2020/11/04 11:34:33 existing blob: sha256:72164b581b02b1eb297b403bcc8fc1bfa245cb52e103a3a525a0835a58ff58e2
2020/11/04 11:34:33 existing blob: sha256:b5d2617265f370f18bc3d48beee684b1ba0eb6a2b02f813353f4bbd7084830ff
2020/11/04 11:34:33 existing blob: sha256:e3a3ae049e8243812509a783d05c2170162d6fb319e07323793cc134f45c8c1c
2020/11/04 11:34:33 existing blob: sha256:abb8a46c328b992b0d33d18d107c86c1c217f33f65b514192dd4af6db2cd9579
2020/11/04 11:34:33 existing blob: sha256:1530cf3c6c2e42e1a7eda6904920aae2fbdf99379f4508a01d083f5a35286672
2020/11/04 11:34:33 existing blob: sha256:458ef48afca43b31f71a9dd56c10f499a3833b0904195936caa007028295fb36
2020/11/04 11:34:34 existing blob: sha256:a722b29e433425d5887a68e8a8e0fb83608253c41c587c92767df6a161efb98c
2020/11/04 11:34:34 existing blob: sha256:34e90a018c82f576b578427df3b9f10a7edce9b4092e97eeaba3877383220d62
2020/11/04 11:34:35 pushed blob: sha256:a7aa79f3381a12cc7448b55057ac0260bf779263d0d75c3e482fe79ffde8519a
2020/11/04 11:34:36 pushed blob: sha256:857adcaa3c1e6434e9c2206aba09bc6f8e56621e11874cac39c758d31762f2f4
2020/11/04 11:34:37 gcr.io/jonjohnson-test/ko/ko@sha256:c918d36a05ccc8513481ce94558faa9c9f4778a22ca7e3a3433bb5745e74c312: digest: sha256:c918d36a05ccc8513481ce94558faa9c9f4778a22ca7e3a3433bb5745e74c312 size: 1737
2020/11/04 11:34:37 existing blob: sha256:72164b581b02b1eb297b403bcc8fc1bfa245cb52e103a3a525a0835a58ff58e2
2020/11/04 11:34:37 existing blob: sha256:0fd2d271697ef75e40cfaf5639cbd0b5730ebe44e841fa156ed503f5c3395c07
2020/11/04 11:34:37 existing blob: sha256:03d95435a5ed135058e1ecb863d16380fbe6fec384761bfc8b95ab54dd59869b
2020/11/04 11:34:37 existing blob: sha256:49114fa10a063d1dd5cf774d3a16ed3b1b5541e0bc0ab45c9a7fde3d9d2616e5
2020/11/04 11:34:37 existing blob: sha256:11ee6330fdd3fb2bbdaee3b0cf6e327884e191d85e257c9d94345c55dbf83b5e
2020/11/04 11:34:37 existing blob: sha256:cfbb6631e0a71a71f08faafe174e0f83ad00c87d97301c2bb19333675f52b630
2020/11/04 11:34:37 existing blob: sha256:8d85c6e4c765c53a774c93445aae80e2222d51681d7eec7dc38f6fce2c1d9fdb
2020/11/04 11:34:37 existing blob: sha256:dcbd85f88306d080bce94006a992947eaf462efa80b07c202b0514e6ef412fdf
2020/11/04 11:34:39 pushed blob: sha256:201c996494c7b2590762462fe24970a24ec383a4fe20163d93fe4e0843829d6a
2020/11/04 11:34:41 pushed blob: sha256:01fe780465c0dc5bdecf7016958df72f47fbfbd7184ab1f5a052d864830d810b
2020/11/04 11:34:41 gcr.io/jonjohnson-test/ko/ko@sha256:07bd970a225acdd2ddf66dc951dba1072be8075d0f95928b35bdc10488e3fcac: digest: sha256:07bd970a225acdd2ddf66dc951dba1072be8075d0f95928b35bdc10488e3fcac size: 1737
2020/11/04 11:34:42 existing blob: sha256:72164b581b02b1eb297b403bcc8fc1bfa245cb52e103a3a525a0835a58ff58e2
2020/11/04 11:34:42 existing blob: sha256:98d6d6258831f87f3b455e6316e2bed430465a760272614de7cdd28c7c6e9f3e
2020/11/04 11:34:42 existing blob: sha256:d23a75d88f9f5980bb112e2c28248975f107144d8d2e40dc4755e2a09f5e56df
2020/11/04 11:34:42 existing blob: sha256:b2a6c4c70f4e593c0500bebe3fa23edab8bd791805ab4a5edf34cb053b21264f
2020/11/04 11:34:42 existing blob: sha256:e75c1905c0573cc5706bc066d23624f0e92a8871832c744fbe7eabdcbc6f8a85
2020/11/04 11:34:42 existing blob: sha256:5e61fff845eda39f31bdf5d797254fdf656ee79d8c294c1713007864bc4c2535
2020/11/04 11:34:42 existing blob: sha256:0bea6d8b9d9b014ffa471b7bb8882ddb7e9d378ddcacc099f0710073bd6361b9
2020/11/04 11:34:42 existing blob: sha256:fe34732f84b95b980d0ae0624ebae44818ef7879e34a9ffbebe752f1dcd4badf
2020/11/04 11:34:42 existing blob: sha256:e0e3f66638c4d5ce9adba16e49844f57efbab1d628d9d6c73133511b7c1c3892
2020/11/04 11:34:42 existing blob: sha256:123678d8baa038225b16066bfa2f971f7454f2d5b16b95db1663954869cf837a
2020/11/04 11:34:42 existing blob: sha256:938695376d9deeba8819539ff3245935c28f93229d1c332bb8b6a16e67013fbc
2020/11/04 11:34:42 existing blob: sha256:41106c6a476cf9666c6d8c3c853c982a841c29db05b3ef8a072baba537b6d74c
2020/11/04 11:34:43 pushed blob: sha256:a60821e95094d409234bcac7e99a6e4abbc3d3ade539cb29ef8efb74cb04eb1e
2020/11/04 11:34:45 pushed blob: sha256:dcdce8890fc47c96ff28053726be3e26792dda9d6481b527a616a83bc4c751e6
2020/11/04 11:34:45 gcr.io/jonjohnson-test/ko/ko@sha256:10e100bd95487f9c4b268f38d7a708e04ab5aa6ca30cdce6ebea065c7f180516: digest: sha256:10e100bd95487f9c4b268f38d7a708e04ab5aa6ca30cdce6ebea065c7f180516 size: 2993
2020/11/04 11:34:46 existing blob: sha256:72164b581b02b1eb297b403bcc8fc1bfa245cb52e103a3a525a0835a58ff58e2
2020/11/04 11:34:46 existing blob: sha256:dcdce8890fc47c96ff28053726be3e26792dda9d6481b527a616a83bc4c751e6
2020/11/04 11:34:46 existing blob: sha256:e300a13db0fbbf48a676ace9db3b0de292c825dfa01e6d82979d96ebc23d3675
2020/11/04 11:34:46 existing blob: sha256:528ba1d9759adcc464112008fe49672e1f545981d69bab31186587ab32f92138
2020/11/04 11:34:46 existing blob: sha256:cd4d95d13c0a45aa19a623e51cb112530a589a3a4d15d5c119610f8196912fab
2020/11/04 11:34:46 existing blob: sha256:8bf8226941bb8f5af9f2be8fdb54da3e3caef344b0061a73e3debde23a55e98f
2020/11/04 11:34:46 existing blob: sha256:53bf4e6180661653575845d30a4d882dea92f395cb540b1cdf91170e9ee58731
2020/11/04 11:34:46 existing blob: sha256:8bbc6767c79760c5d4cd356ae2dd0742f8d13be9298959aa3009b1e4d2c18cbc
2020/11/04 11:34:46 existing blob: sha256:14b8d8683ed903732b7672eb374d957e4ad20a8936cd48bc9a69059c19163325
2020/11/04 11:34:46 existing blob: sha256:b38f6e003c1013456c5993d4c122314dab53690c52405c373b2055e636353e47
2020/11/04 11:34:46 existing blob: sha256:8934a016b666d0691307c6414d84c36eb82de4b2fc4d74dd04c75f632dc3a78c
2020/11/04 11:34:46 existing blob: sha256:1089b875ac355097876e23760dd2166f096a8645e312660ffd3c0e617a2df9a0
2020/11/04 11:34:46 existing blob: sha256:53e973f094614bb2cebe16df6f6004c05895ed077151aecdbbd0c476513054fc
2020/11/04 11:34:47 pushed blob: sha256:6c7cd50106f3e1ad72bc24e046d47ae33b41e3920b1b7d1a5b50742efa465d07
2020/11/04 11:34:48 gcr.io/jonjohnson-test/ko/ko@sha256:c9e8ab3b00eaca483d3784720c5072b1516129eb97d09911a74c43ad89973933: digest: sha256:c9e8ab3b00eaca483d3784720c5072b1516129eb97d09911a74c43ad89973933 size: 2916
2020/11/04 11:34:48 gcr.io/jonjohnson-test/ko/ko:latest: digest: sha256:6f316758f1f23321780a37010894bfd98e6d14b6248d9baf6b5c3551249075ee size: 2345
2020/11/04 11:34:48 Published gcr.io/jonjohnson-test/ko/ko@sha256:6f316758f1f23321780a37010894bfd98e6d14b6248d9baf6b5c3551249075ee
```
```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
  "manifests": [
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 1737,
      "digest": "sha256:6f777bfc2417d9282b981aef39049a45e3a97049106fbfc9265dc5245fa3ec89",
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 1737,
      "digest": "sha256:225dcfc690d5d677e7ac71b9261cf8d7c82606c551ce14c87bb9b4f32b826610",
      "platform": {
        "architecture": "arm",
        "os": "linux",
        "variant": "v5"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 1736,
      "digest": "sha256:5d0e62c2b235271442d9eca9c851914bed3e0ba9c1298b517b270e34d80dcf6f",
      "platform": {
        "architecture": "arm",
        "os": "linux",
        "variant": "v7"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 1736,
      "digest": "sha256:bf35a275d966f45a4a57ab31cf016b16fef49e544edd603547a5193a4dc91e1b",
      "platform": {
        "architecture": "arm64",
        "os": "linux",
        "variant": "v8"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 1738,
      "digest": "sha256:a5ee0f4a4d800ea0384618e6fc0ea6c9efb46b3434e7496c059e8685a8923006",
      "platform": {
        "architecture": "386",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 1738,
      "digest": "sha256:20614018734dd0ccf48a31a05a5ae1c40d09192ec54b1b11da3148fa3ea94628",
      "platform": {
        "architecture": "mips64le",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 1737,
      "digest": "sha256:c918d36a05ccc8513481ce94558faa9c9f4778a22ca7e3a3433bb5745e74c312",
      "platform": {
        "architecture": "ppc64le",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 1737,
      "digest": "sha256:07bd970a225acdd2ddf66dc951dba1072be8075d0f95928b35bdc10488e3fcac",
      "platform": {
        "architecture": "s390x",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 2993,
      "digest": "sha256:10e100bd95487f9c4b268f38d7a708e04ab5aa6ca30cdce6ebea065c7f180516",
      "platform": {
        "architecture": "amd64",
        "os": "windows",
        "os.version": "10.0.17763.1518"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 2916,
      "digest": "sha256:c9e8ab3b00eaca483d3784720c5072b1516129eb97d09911a74c43ad89973933",
      "platform": {
        "architecture": "amd64",
        "os": "windows",
        "os.version": "10.0.14393.3986"
      }
    }
  ]
}
```

Note that the last layer is the binary:
```
$ crane config gcr.io/jonjohnson-test/ko/ko@sha256:5d0e62c2b235271442d9eca9c851914bed3e0ba9c1298b517b270e34d80dcf6f | jq .history[-1]
{
  "author": "ko",
  "created": "0001-01-01T00:00:00Z",
  "created_by": "ko publish ko://github.com/google/ko/cmd/ko",
  "comment": "go build output, at /ko-app/ko"
}
```

The last layers are different, which indicates that we build different artifacts based on the variant:
```
$ diff <(crane manifest gcr.io/jonjohnson-test/ko/ko@sha256:5d0e62c2b235271442d9eca9c851914bed3e0ba9c1298b517b270e34d80dcf6f | jq .layers[-1].digest) <(crane manifest gcr.io/jonjohnson-test/ko/ko@sha256:225dcfc690d5d677e7ac71b9261cf8d7c82606c551ce14c87bb9b4f32b826610 | jq .layers[-1].digest)
1c1
< "sha256:75fd71fb32482cfe78b28ccbcf655ff2422677b08594bc615548b7f5aff8649a"
---
> "sha256:14900bcb6baeafeb4363c288eda6d44669f52fab63d61f4d95071bf9b6806651"
```