### PR TITLE
Print variant from builder

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -231,6 +231,14 @@ func getGoarm(platform v1.Platform) (string, error) {
 	return "", nil
 }
 
+// TODO(jonjohnsonjr): Upstream something like this.
+func platformToString(p v1.Platform) string {
+	if p.Variant != "" {
+		return fmt.Sprintf("%s/%s/%s", p.OS, p.Architecture, p.Variant)
+	}
+	return fmt.Sprintf("%s/%s", p.OS, p.Architecture)
+}
+
 func build(ctx context.Context, ip string, platform v1.Platform, disableOptimizations bool) (string, error) {
 	tmpDir, err := ioutil.TempDir("", "ko")
 	if err != nil {
@@ -272,7 +280,7 @@ func build(ctx context.Context, ip string, platform v1.Platform, disableOptimiza
 	cmd.Stderr = &output
 	cmd.Stdout = &output
 
-	log.Printf("Building %s for %s/%s", ip, platform.OS, platform.Architecture)
+	log.Printf("Building %s for %s", ip, platformToString(platform))
 	if err := cmd.Run(); err != nil {
 		os.RemoveAll(tmpDir)
 		log.Printf("Unexpected error running \"go build\": %v\n%v", err, output.String())


### PR DESCRIPTION
```
$ crane manifest alpine | jq .
```
```json
{
  "manifests": [
    {
      "digest": "sha256:d7342993700f8cd7aba8496c2d0e57be0666e80b4c441925fc6f9361fa81d10e",
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      },
      "size": 528
    },
    {
      "digest": "sha256:c4f0f03cda416f3e4cfebcfea9910463121651b019c6677053ece71084699f47",
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "platform": {
        "architecture": "arm",
        "os": "linux",
        "variant": "v6"
      },
      "size": 528
    },
    {
      "digest": "sha256:d0f78a6ddf7a457dc72dbd44eab67209454ddb1e6d2323fa8e27275bc13dc320",
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "platform": {
        "architecture": "arm",
        "os": "linux",
        "variant": "v7"
      },
      "size": 528
    },
    {
      "digest": "sha256:fbb820c07896f5c2516167e7146d9938fc82d4b6b1db167defa5b0a7162e4480",
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "platform": {
        "architecture": "arm64",
        "os": "linux",
        "variant": "v8"
      },
      "size": 528
    },
    {
      "digest": "sha256:4e01ddea8def856ba9fee17668fa0b2e45a8bc78127b7ab6cf921f6d6fd86ac9",
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "platform": {
        "architecture": "386",
        "os": "linux"
      },
      "size": 528
    },
    {
      "digest": "sha256:e565d01665c4596b34d7836fc370342331b836b5e5623eb1c8dfaf72ef4f30cb",
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "platform": {
        "architecture": "ppc64le",
        "os": "linux"
      },
      "size": 528
    },
    {
      "digest": "sha256:eb005f6396161741e490161756dac662e946206c9d2e7ff2528be60e905be9f6",
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "platform": {
        "architecture": "s390x",
        "os": "linux"
      },
      "size": 528
    }
  ],
  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
  "schemaVersion": 2
}
```
```
$ KO_DEFAULTBASEIMAGE=alpine ko publish --platform=all ./cmd/ko
2020/11/17 14:42:24 Using base alpine for github.com/google/ko/cmd/ko
2020/11/17 14:42:24 No matching credentials were found, falling back on anonymous
2020/11/17 14:42:25 Building github.com/google/ko/cmd/ko for linux/amd64
2020/11/17 14:42:33 Building github.com/google/ko/cmd/ko for linux/arm/v6
2020/11/17 14:42:40 Building github.com/google/ko/cmd/ko for linux/arm/v7
2020/11/17 14:43:19 Building github.com/google/ko/cmd/ko for linux/arm64/v8
2020/11/17 14:44:26 Building github.com/google/ko/cmd/ko for linux/386
2020/11/17 14:45:35 Building github.com/google/ko/cmd/ko for linux/ppc64le
2020/11/17 14:46:43 Building github.com/google/ko/cmd/ko for linux/s390x
...
```