### PR TITLE
Allow comma-separated list of platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,9 @@ script:
   - go install -mod=vendor ./cmd/ko
   # Try with all, and GOOS/GOARCH set.
   - |
-    GOOS=${GOOS} GOARCH=${GOARCH} KO_DOCKER_REPO=ko.local ko publish --platform=all -B ./cmd/ko/test
-    OUTPUT=$(docker run -i ko.local/test -wait=false 2>&1)
-    if [[ ! "${OUTPUT}" =~ "$(cat ./cmd/ko/test/kodata/kenobi)" ]]; then
-      echo Mismatched output: ${OUTPUT}, wanted: $(cat ./cmd/ko/test/kodata/kenobi)
-      exit 1
-    fi
-    if [[ ! "${OUTPUT}" =~ "$(cat ./cmd/ko/test/kodata/HEAD)" ]]; then
-      echo Mismatched output: ${OUTPUT}, wanted: $(cat ./cmd/ko/test/kodata/HEAD)
+    OUTPUT=$(GOOS=${GOOS} GOARCH=${GOARCH} KO_DOCKER_REPO=ko.local ko publish --platform=all -B ./cmd/ko/test 2>&1)
+    if [[ ! "${OUTPUT}" =~ "cannot use --platform with GOOS=\"${GOOS}\"" ]]; then
+      echo Mismatched output: ${OUTPUT}, wanted: "cannot use --platform with GOOS=\"${GOOS}\""
       exit 1
     fi
 

--- a/README.md
+++ b/README.md
@@ -454,13 +454,25 @@ a multi-architecture
 (aka "manifest list"), with support for each OS and architecture pair supported
 by the base image.
 
-If `ko` is invoked with `--platform=<some-OS>/<some-platform>` (e.g.,
+If `ko` is invoked with `--platform=<some-OS>/<some-arch>` (e.g.,
 `--platform=linux/amd64` or `--platform=linux/arm64`), then it will attempt to
 build an image for that OS and architecture only, assuming the base image
 supports it.
 
-When `--platform` is not provided, `ko` builds an image with the OS and
-architecture based on the build environment's `GOOS` and `GOARCH`.
+If the base image is a manifest list with more platforms than you want to build,
+invoking `ko` with comma-separated list of platforms (e.g.
+`--platform=linux/amd64,linux/arm/v6`) will produce a manifest list
+containing only the provided platforms. Note that if the base image does not
+contain platforms that are provided by this flag, `ko` will be unable to build
+a corresponding image, and this is not an error. The resulting artifact will be
+a multi-platform image containing the intersection of platforms from the base
+image and the `--platform` flag. This is especially relevant for projects that
+use multiple base images, as you must ensure that every base image contains all
+the platforms that you'd like to build.
+
+When `--platform` is not provided, if both `GOOS` and `GOARCH` environment
+variables are set, `ko` will build an image for `${GOOS}/${GOARCH}`, otherwise
+`ko` will build a `linux/amd64` image.
 
 ## Enable Autocompletion
 

--- a/README.md
+++ b/README.md
@@ -471,8 +471,11 @@ use multiple base images, as you must ensure that every base image contains all
 the platforms that you'd like to build.
 
 When `--platform` is not provided, if both `GOOS` and `GOARCH` environment
-variables are set, `ko` will build an image for `${GOOS}/${GOARCH}`, otherwise
-`ko` will build a `linux/amd64` image.
+variables are set, `ko` will build an image for `${GOOS}/${GOARCH}[/v${GOARM}]`,
+otherwise `ko` will build a `linux/amd64` image.
+
+Note that using both `--platform` and GOOS/GOARCH will return an error, as it's
+unclear what platform should be used.
 
 ## Enable Autocompletion
 

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -672,8 +672,7 @@ func TestMatchesPlatformSpec(t *testing.T) {
 			OS:           "linux",
 		},
 		result: false,
-	},
-	} {
+	}} {
 		parsed, err := parseSpec(tc.spec)
 		if tc.err {
 			if err == nil {

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -671,10 +671,10 @@ func TestMatchesPlatformSpec(t *testing.T) {
 			Architecture: "amd64",
 			OS:           "linux",
 		},
-		err: true,
+		result: false,
 	},
 	} {
-		matches, err := matchesPlatformSpec(tc.platform, tc.spec)
+		parsed, err := parseSpec(tc.spec)
 		if tc.err {
 			if err == nil {
 				t.Errorf("matchesPlatformSpec(%v, %q) expected err", tc.platform, tc.spec)
@@ -684,6 +684,7 @@ func TestMatchesPlatformSpec(t *testing.T) {
 		if err != nil {
 			t.Fatalf("matchesPlatformSpec failed for %v %q: %v", tc.platform, tc.spec, err)
 		}
+		matches := matchesPlatformSpec(tc.platform, tc.spec, parsed)
 		if got, want := matches, tc.result; got != want {
 			t.Errorf("wrong result for %v %q: want %t got %t", tc.platform, tc.spec, want, got)
 		}

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -673,17 +673,17 @@ func TestMatchesPlatformSpec(t *testing.T) {
 		},
 		result: false,
 	}} {
-		parsed, err := parseSpec(tc.spec)
+		pm, err := parseSpec(tc.spec)
 		if tc.err {
 			if err == nil {
-				t.Errorf("matchesPlatformSpec(%v, %q) expected err", tc.platform, tc.spec)
+				t.Errorf("parseSpec(%v, %q) expected err", tc.platform, tc.spec)
 			}
 			continue
 		}
 		if err != nil {
-			t.Fatalf("matchesPlatformSpec failed for %v %q: %v", tc.platform, tc.spec, err)
+			t.Fatalf("parseSpec failed for %v %q: %v", tc.platform, tc.spec, err)
 		}
-		matches := matchesPlatformSpec(tc.platform, tc.spec, parsed)
+		matches := pm.matches(tc.platform)
 		if got, want := matches, tc.result; got != want {
 			t.Errorf("wrong result for %v %q: want %t got %t", tc.platform, tc.spec, want, got)
 		}

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -45,6 +45,19 @@ func WithDisabledOptimizations() Option {
 	}
 }
 
+// WithPlatforms is a functional option for building certain platforms for
+// multi-platform base images. To build everything from the base, use "all",
+// otherwise use a comma-separated list of platform specs, i.e.:
+//
+// platform = <os>[/<arch>[/<variant>]]
+// allowed = all | platform[,platform]*
+func WithPlatforms(platforms string) Option {
+	return func(gbo *gobuildOpener) error {
+		gbo.platform = platforms
+		return nil
+	}
+}
+
 // withBuilder is a functional option for overriding the way go binaries
 // are built.
 func withBuilder(b builder) Option {

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -20,7 +20,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"path"
 	"strconv"
 	"strings"
 	"syscall"
@@ -41,16 +40,6 @@ var (
 )
 
 func getBaseImage(platform string) build.GetBase {
-	// Default to linux/amd64 unless GOOS and GOARCH are set.
-	if platform == "" {
-		platform = "linux/amd64"
-
-		goos, goarch := os.Getenv("GOOS"), os.Getenv("GOARCH")
-		if goos != "" && goarch != "" {
-			platform = path.Join(goos, goarch)
-		}
-	}
-
 	return func(ctx context.Context, s string) (build.Result, error) {
 		s = strings.TrimPrefix(s, build.StrictScheme)
 		// Viper configuration file keys are case insensitive, and are
@@ -71,8 +60,12 @@ func getBaseImage(platform string) build.GetBase {
 
 		// Using --platform=all will use an image index for the base,
 		// otherwise we'll resolve it to the appropriate platform.
+		//
+		// Platforms can be comma-separated if we only want a subset of the base
+		// image.
+		multiplatform := platform == "all" || strings.Contains(platform, ",")
 		var p v1.Platform
-		if platform != "" && platform != "all" {
+		if platform != "" && !multiplatform {
 			parts := strings.Split(platform, "/")
 			if len(parts) > 0 {
 				p.OS = parts[0]
@@ -96,7 +89,7 @@ func getBaseImage(platform string) build.GetBase {
 		}
 		switch desc.MediaType {
 		case types.OCIImageIndex, types.DockerManifestList:
-			if platform == "all" {
+			if multiplatform {
 				return desc.ImageIndex()
 			}
 			return desc.Image()

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -33,6 +33,5 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 	cmd.Flags().BoolVar(&bo.DisableOptimizations, "disable-optimizations", bo.DisableOptimizations,
 		"Disable optimizations when building Go code. Useful when you want to interactively debug the created container.")
 	cmd.Flags().StringVar(&bo.Platform, "platform", "",
-		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]]")
-
+		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*")
 }

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path"
 	"strings"
 	"sync"
 
@@ -69,8 +70,21 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	platform := bo.Platform
+	// Default to linux/amd64 unless GOOS and GOARCH are set.
+	if platform == "" {
+		platform = "linux/amd64"
+
+		goos, goarch := os.Getenv("GOOS"), os.Getenv("GOARCH")
+		if goos != "" && goarch != "" {
+			platform = path.Join(goos, goarch)
+		}
+	}
+
 	opts := []build.Option{
-		build.WithBaseImages(getBaseImage(bo.Platform)),
+		build.WithBaseImages(getBaseImage(platform)),
+		build.WithPlatforms(platform),
 	}
 	if creationTime != nil {
 		opts = append(opts, build.WithCreationTime(*creationTime))

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -72,13 +72,26 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 	}
 
 	platform := bo.Platform
-	// Default to linux/amd64 unless GOOS and GOARCH are set.
 	if platform == "" {
 		platform = "linux/amd64"
 
-		goos, goarch := os.Getenv("GOOS"), os.Getenv("GOARCH")
+		goos, goarch, goarm := os.Getenv("GOOS"), os.Getenv("GOARCH"), os.Getenv("GOARM")
+
+		// Default to linux/amd64 unless GOOS and GOARCH are set.
 		if goos != "" && goarch != "" {
 			platform = path.Join(goos, goarch)
+		}
+
+		// Use GOARM for variant if it's set and GOARCH is arm.
+		if strings.Contains(goarch, "arm") && goarm != "" {
+			platform = path.Join(platform, "v"+goarm)
+		}
+	} else {
+		// Make sure these are all unset
+		for _, env := range []string{"GOOS", "GOARCH", "GOARM"} {
+			if s, ok := os.LookupEnv(env); ok {
+				return nil, fmt.Errorf("cannot use --platform with %s=%q", env, s)
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/google/ko/issues/253

Fixes https://github.com/google/ko/issues/274

```
$ ko publish -B --platform=linux/amd64,linux/arm64 ./cmd/ko/
2020/12/07 13:57:20 Using base gcr.io/distroless/static:nonroot for github.com/google/ko/cmd/ko
2020/12/07 13:57:21 Building github.com/google/ko/cmd/ko for linux/amd64
2020/12/07 13:57:25 Building github.com/google/ko/cmd/ko for linux/arm64
2020/12/07 13:57:29 Publishing gcr.io/jonjohnson-test/ko/ko:latest
2020/12/07 13:57:30 existing blob: sha256:72164b581b02b1eb297b403bcc8fc1bfa245cb52e103a3a525a0835a58ff58e2
2020/12/07 13:57:30 existing blob: sha256:e59bd8947ac7af2c8f4403b183326986ab554bbc262739cf5d9d596c7c7a3aca
2020/12/07 13:57:31 pushed blob: sha256:314bd22f324d73c81d23dd94a14e3a4df6a591381e39b9164163208115c23ae4
2020/12/07 13:57:33 pushed blob: sha256:dd714425e64113dddc2cf7a21a1b7f47c20ae29dc2072284b64fe1e7b82a5307
2020/12/07 13:57:33 gcr.io/jonjohnson-test/ko/ko@sha256:cb6a0c6cb99e6c7b1d7dfd598484d0d25b74e15a69837f3d87c08c58ee7f88e2: digest: sha256:cb6a0c6cb99e6c7b1d7dfd598484d0d25b74e15a69837f3d87c08c58ee7f88e2 size: 751
2020/12/07 13:57:34 existing blob: sha256:72164b581b02b1eb297b403bcc8fc1bfa245cb52e103a3a525a0835a58ff58e2
2020/12/07 13:57:34 existing blob: sha256:d34b09c140e4b67f2c6214e24f26a68bc6b17c28d42f0dda89db38ad03488416
2020/12/07 13:57:35 pushed blob: sha256:99af2cd1b289d3a47aba52934e2ac8c4037e92563e8a4d119b5d0e040f5b9ed3
2020/12/07 13:57:37 pushed blob: sha256:052d3194d06e9194d60e7dcdce4c7d8e91df952f34dfddd461ce181732342db2
2020/12/07 13:57:37 gcr.io/jonjohnson-test/ko/ko@sha256:ca19f1aa2adc983e55c1eb7d6af1ed8574991ff6762eccec8ef7b5e5d965d1ce: digest: sha256:ca19f1aa2adc983e55c1eb7d6af1ed8574991ff6762eccec8ef7b5e5d965d1ce size: 751
2020/12/07 13:57:38 gcr.io/jonjohnson-test/ko/ko:latest: digest: sha256:03ed41dd8676e9988fb4958366cf8d38fbb39e576d5b09bb1cc108c937e6d7ff size: 529
2020/12/07 13:57:38 Published gcr.io/jonjohnson-test/ko/ko@sha256:03ed41dd8676e9988fb4958366cf8d38fbb39e576d5b09bb1cc108c937e6d7ff
gcr.io/jonjohnson-test/ko/ko@sha256:03ed41dd8676e9988fb4958366cf8d38fbb39e576d5b09bb1cc108c937e6d7ff
```