### PR TITLE
Introduce KOCACHE

### DIFF
--- a/pkg/build/cache.go
+++ b/pkg/build/cache.go
@@ -1,0 +1,210 @@
+// Copyright 2021 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+)
+
+type diffIDToDescriptor map[v1.Hash]v1.Descriptor
+type buildIDToDiffID map[string]v1.Hash
+
+type layerCache struct {
+	buildToDiff map[string]buildIDToDiffID
+	diffToDesc  map[string]diffIDToDescriptor
+	sync.Mutex
+}
+
+type layerFactory func() (v1.Layer, error)
+
+func (c *layerCache) get(ctx context.Context, file string, miss layerFactory) (v1.Layer, error) {
+	if os.Getenv("KOCACHE") == "" {
+		return miss()
+	}
+
+	// Cache hit.
+	if diffid, desc, err := c.getMeta(ctx, file); err == nil {
+		return &lazyLayer{
+			diffid:     *diffid,
+			desc:       *desc,
+			buildLayer: miss,
+		}, nil
+	}
+
+	// Cache miss.
+	layer, err := miss()
+	if err != nil {
+		return nil, err
+	}
+	if err := c.put(ctx, file, layer); err != nil {
+		log.Printf("failed to cache metadata %s: %v", file, err)
+	}
+	return layer, nil
+}
+
+func (c *layerCache) getMeta(ctx context.Context, file string) (*v1.Hash, *v1.Descriptor, error) {
+	buildid, err := getBuildID(ctx, file)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if buildid == "" {
+		return nil, nil, fmt.Errorf("no buildid for %s", file)
+	}
+
+	btod, err := c.readBuildToDiff(file)
+	if err != nil {
+		return nil, nil, err
+	}
+	dtod, err := c.readDiffToDesc(file)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	diffid, ok := btod[buildid]
+	if !ok {
+		return nil, nil, fmt.Errorf("no diffid for %q", buildid)
+	}
+
+	desc, ok := dtod[diffid]
+	if !ok {
+		return nil, nil, fmt.Errorf("no desc for %q", diffid)
+	}
+
+	return &diffid, &desc, nil
+}
+
+// Compute new layer metadata and cache it in-mem and on-disk.
+func (c *layerCache) put(ctx context.Context, file string, layer v1.Layer) error {
+	buildid, err := getBuildID(ctx, file)
+	if err != nil {
+		return err
+	}
+
+	desc, err := partial.Descriptor(layer)
+	if err != nil {
+		return err
+	}
+
+	diffid, err := layer.DiffID()
+	if err != nil {
+		return err
+	}
+
+	btod, ok := c.buildToDiff[file]
+	if !ok {
+		btod = buildIDToDiffID{}
+	}
+	btod[buildid] = diffid
+
+	dtod, ok := c.diffToDesc[file]
+	if !ok {
+		dtod = diffIDToDescriptor{}
+	}
+	dtod[diffid] = *desc
+
+	// TODO: Implement better per-file locking.
+	c.Lock()
+	defer c.Unlock()
+
+	btodf, err := os.OpenFile(filepath.Join(filepath.Dir(file), "buildid-to-diffid"), os.O_RDWR|os.O_CREATE, 0755)
+	if err != nil {
+		return err
+	}
+	defer btodf.Close()
+
+	dtodf, err := os.OpenFile(filepath.Join(filepath.Dir(file), "diffid-to-descriptor"), os.O_RDWR|os.O_CREATE, 0755)
+	if err != nil {
+		return err
+	}
+	defer dtodf.Close()
+
+	enc := json.NewEncoder(btodf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(&btod); err != nil {
+		return err
+	}
+
+	enc = json.NewEncoder(dtodf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(&dtod); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *layerCache) readDiffToDesc(file string) (diffIDToDescriptor, error) {
+	if dtod, ok := c.diffToDesc[file]; ok {
+		return dtod, nil
+	}
+
+	dtodf, err := os.Open(filepath.Join(filepath.Dir(file), "diffid-to-descriptor"))
+	if err != nil {
+		return nil, err
+	}
+	defer dtodf.Close()
+
+	var dtod diffIDToDescriptor
+	if err := json.NewDecoder(dtodf).Decode(&dtod); err != nil {
+		return nil, err
+	}
+	c.diffToDesc[file] = dtod
+	return dtod, nil
+}
+
+func (c *layerCache) readBuildToDiff(file string) (buildIDToDiffID, error) {
+	if btod, ok := c.buildToDiff[file]; ok {
+		return btod, nil
+	}
+
+	btodf, err := os.Open(filepath.Join(filepath.Dir(file), "buildid-to-diffid"))
+	if err != nil {
+		return nil, err
+	}
+	defer btodf.Close()
+
+	var btod buildIDToDiffID
+	if err := json.NewDecoder(btodf).Decode(&btod); err != nil {
+		return nil, err
+	}
+	c.buildToDiff[file] = btod
+	return btod, nil
+}
+
+func getBuildID(ctx context.Context, file string) (string, error) {
+	cmd := exec.CommandContext(ctx, "go", "tool", "buildid", file)
+	var output bytes.Buffer
+	cmd.Stderr = &output
+	cmd.Stdout = &output
+
+	if err := cmd.Run(); err != nil {
+		log.Printf("Unexpected error running \"go tool buildid %s\": %v\n%v", err, file, output.String())
+		return "", err
+	}
+	return strings.TrimSpace(output.String()), nil
+}

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -249,7 +249,7 @@ func build(ctx context.Context, ip string, dir string, platform v1.Platform, con
 
 	if dir := os.Getenv("KOCACHE"); dir != "" {
 		// TODO(#264): if KOCACHE is unset, default to filepath.Join(os.TempDir(), "ko").
-		tmpDir = filepath.Join(dir, ip, platformToString(platform))
+		tmpDir = filepath.Join(dir, "bin", ip, platformToString(platform))
 		if err := os.MkdirAll(tmpDir, os.ModePerm); err != nil {
 			return "", err
 		}

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -257,7 +257,7 @@ func build(ctx context.Context, ip string, dir string, platform v1.Platform, con
 	}
 
 	if dir := os.Getenv("KOCACHE"); dir != "" {
-		// TODO(jonjohnsonjr): if KOCACHE is unset, default to filepath.Join(os.TempDir(), "ko").
+		// TODO(#264): if KOCACHE is unset, default to filepath.Join(os.TempDir(), "ko").
 		tmpDir = filepath.Join(dir, ip, platformToString(platform))
 		if err := os.MkdirAll(tmpDir, os.ModePerm); err != nil {
 			return "", err

--- a/pkg/build/layer.go
+++ b/pkg/build/layer.go
@@ -1,0 +1,75 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"io"
+	"sync"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+type lazyLayer struct {
+	diffid v1.Hash
+	desc   v1.Descriptor
+
+	sync.Once
+	buildLayer func() (v1.Layer, error)
+	layer      v1.Layer
+	err        error
+}
+
+// All this info is cached by previous builds.
+func (l *lazyLayer) Digest() (v1.Hash, error) {
+	return l.desc.Digest, nil
+}
+
+func (l *lazyLayer) DiffID() (v1.Hash, error) {
+	return l.diffid, nil
+}
+
+func (l *lazyLayer) Size() (int64, error) {
+	return l.desc.Size, nil
+}
+
+func (l *lazyLayer) MediaType() (types.MediaType, error) {
+	return l.desc.MediaType, nil
+}
+
+// This is only called if the registry doesn't have this blob already.
+func (l *lazyLayer) Compressed() (io.ReadCloser, error) {
+	layer, err := l.compute()
+	if err != nil {
+		return nil, err
+	}
+	return layer.Compressed()
+}
+
+// This should never actually be called but we need it to impl v1.Layer.
+func (l *lazyLayer) Uncompressed() (io.ReadCloser, error) {
+	layer, err := l.compute()
+	if err != nil {
+		return nil, err
+	}
+	return layer.Uncompressed()
+}
+
+func (l *lazyLayer) compute() (v1.Layer, error) {
+	l.Once.Do(func() {
+		l.layer, l.err = l.buildLayer()
+	})
+	return l.layer, l.err
+}


### PR DESCRIPTION
Start of https://github.com/google/ko/issues/264

Currently, use this by setting `KOCACHE=/tmp/ko` (or any directory you want). We can default to doing this in the future.

We will cache binaries and metdata under `$KOCACHE/bin/<import path>/<platform>`:

```
$ tree /tmp/ko
/tmp/ko                                                                                                                                                                                                                                                                                                                        
`-- bin                                                                                                                                                                                                                                                                                                                        
    `-- github.com                                                                                                                                                                                                                                                                                                             
        `-- google                                                                                                                                                                                                                                                                                                             
            `-- ko                                                                                                                                                                                                                                                                                                             
                `-- linux                                                                                                                                                                                                                                                                                                      
                    |-- amd64                                                                                                                                                                                                                                                                                                  
                    |   |-- buildid-to-diffid                                                                                                                                                                                                                                                                                  
                    |   |-- diffid-to-descriptor                                                                                                                                                                                                                                                                               
                    |   `-- out                                                                                                                                                                                                                                                                                                
                    |-- arm                                                                                                                                                                                                                                                                                                    
                    |   |-- buildid-to-diffid                                                                                                                                                                                                                                                                                  
                    |   |-- diffid-to-descriptor                                                                                                                                                                                                                                                                               
                    |   `-- out                                                                                                                                                                                                                                                                                                
                    |-- arm64                                                                                                                                                                                                                                                                                                  
                    |   |-- buildid-to-diffid                                                                                                                                                                                                                                                                                  
                    |   |-- diffid-to-descriptor                                                                                                                                                                                                                                                                               
                    |   `-- out                                                                                                                                                                                                                                                                                                
                    |-- ppc64le                                                                                                                                                                                                                                                                                                
                    |   |-- buildid-to-diffid                                                                                                                                                                                                                                                                                  
                    |   |-- diffid-to-descriptor                                                                                                                                                                                                                                                                               
                    |   `-- out                                                                                                                                                                                                                                                                                                
                    `-- s390x                                                                                                                                                                                                                                                                                                  
                        |-- buildid-to-diffid                                                                                                                                                                                                                                                                                  
                        |-- diffid-to-descriptor                                                                                                                                                                                                                                                                               
                        `-- out   
```

In `buildid-to-diffid`, we maintain a map from the binary's buildid to the diffid we produced from it:

```
$ cat /tmp/ko/bin/github.com/google/ko/linux/amd64/buildid-to-diffid 
{
  "DpZ76uEtG19-5zUMMduu/ZydApuKMqo03IenzJjld/E9kHVxb9IXx9H09h2JH0/vW8Nmsi20Na9bBDsFDYX": "sha256:fb701193c5e0cedb4291fb7308219cc95ec20afe04e24491be1cedf72c3f7a4a",
  "IL1S_KSUq5wIP90ZkKhZ/j-1pixYk9Al_YB-B02oM/QDXIdXeDJc-14xTSVCTB/7wkOkmLWlnCRO42sVTBS": "sha256:d7640b5ef558e77eb69caac1405be6729dde3c7a4c9ccb6ba7fb4ea3812858ca"
}
```

You can determine the buildid from the binary:
```
$ go tool buildid /tmp/ko/bin/github.com/google/ko/linux/amd64/out 
IL1S_KSUq5wIP90ZkKhZ/j-1pixYk9Al_YB-B02oM/QDXIdXeDJc-14xTSVCTB/7wkOkmLWlnCRO42sVTBS
```

Which allows us to skip computing the diffid (tar + sha256) at all.

In `diffid-to-descriptor`, we maintain a map from diffid to a layer descriptor:

```
$ cat /tmp/ko/bin/github.com/google/ko/linux/amd64/diffid-to-descriptor 
{
  "sha256:d7640b5ef558e77eb69caac1405be6729dde3c7a4c9ccb6ba7fb4ea3812858ca": {
    "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
    "size": 12162562,
    "digest": "sha256:d4695baddba464a9e730d1d7580ae2aba998ae77980de64b1c4b28a945412519"
  },
  "sha256:fb701193c5e0cedb4291fb7308219cc95ec20afe04e24491be1cedf72c3f7a4a": {
    "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
    "size": 12173723,
    "digest": "sha256:ddc4badd9eacf3b55c9254ca62bd737b3994f8b1c03e99f9873e776889cd2c2b"
  }
}
```

... which is enough info to HEAD the blob in-registry without having to actually re-gzip it.

This is a separate structure from `buildid-to-diffid` so that we can decouple `diffid-to-descriptor` from go builds and reuse it for the kodata layers (or really anything -- docker does very similar stuff here): https://github.com/google/ko/issues/262

@mattmoor @ImJasonH

# Numbers

Warm + cache miss (and fill) + registry miss:
```
$ time KOCACHE=/tmp/ko KO_DOCKER_REPO=localhost:1338/ko ko publish --platform=all .

real  0m10.501s
user  0m11.848s
sys   0m4.252s
```

Warm + cache miss (and fill) + registry hits:
```
$ time KOCACHE=/tmp/ko KO_DOCKER_REPO=localhost:1338/ko ko publish --platform=all .

real  0m9.456s
user  0m11.410s
sys   0m4.165s
```

Warm + cache hits + registry miss:
```
$ time KOCACHE=/tmp/ko KO_DOCKER_REPO=localhost:1338/ko ko publish --platform=all .

real  0m5.721s
user  0m6.478s
sys   0m3.758s
```

Warm + cache hits + registry hits:
```
$ time KOCACHE=/tmp/ko KO_DOCKER_REPO=localhost:1338/ko ko publish --platform=all .

real  0m4.071s
user  0m5.216s
sys   0m4.358s
```

What more can we do? Well... about half of this time is actually spent fetching the base image. If we pull that down to a local registry:

```
$ crane cp gcr.io/distroless/static:nonroot localhost:1338/distroless:nonroot
$ time KO_DEFAULTBASEIMAGE=localhost:1338/distroless:nonroot KOCACHE=/tmp/ko KO_DOCKER_REPO=localhost:1338/ko ko publish --platform=all .

real  0m1.682s
user  0m3.750s
sys   0m2.630s
```

Starting towards achieving that in https://github.com/google/ko/pull/525