### PR TITLE
Add ko login

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ container registry is via `docker login`, and `ko` does not require users to
 install `docker` locally. To facilitate logging in without `docker` we expose:
 
 ```shell
-ko auth login my.registry.io -u username --password-stdin
+ko login my.registry.io -u username --password-stdin
 ```
 
 ## The `ko` Model

--- a/cmd/ko/main.go
+++ b/cmd/ko/main.go
@@ -41,7 +41,13 @@ func main() {
 
 	// Also add the auth group from crane to facilitate logging into a
 	// registry.
-	cmds.AddCommand(cranecmd.NewCmdAuth())
+	authCmd := cranecmd.NewCmdAuth("ko", "auth")
+	// That was a mistake, but just set it to Hidden so we don't break people.
+	authCmd.Hidden = true
+	cmds.AddCommand(authCmd)
+
+	// Just add a `ko login` command:
+	cmds.AddCommand(cranecmd.NewCmdAuthLogin())
 
 	if err := cmds.Execute(); err != nil {
 		log.Fatalf("error during command execution: %v", err)


### PR DESCRIPTION
Fixes https://github.com/google/ko/issues/155

This was previously `ko auth login`, which I've hidden, and perhaps we
can alias to `ko login` in the future, but in theory folks could have
been using `ko auth get`, and I don't want to break that for no reason.