### PR TITLE
Fix .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ before:
     # you may remove this if you don't need go generate
     - go generate ./...
 builds:
-- main: ./cmd/ko/main.go
+- main: ./main.go
   env:
   - CGO_ENABLED=0
   flags:


### PR DESCRIPTION
The 0.7.0 release is warning that folks should stop using `./cmd/ko`...  oops.

After this lands, we should CP and cut 0.7.1