### PR TITLE
fixed: comment and readme are incorrect, there is no ko login

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ container registry is via `docker login`, and `ko` does not require users to
 install `docker` locally. To facilitate logging in without `docker` we expose:
 
 ```shell
-ko login my.registry.io -u username --password-stdin
+ko auth login my.registry.io -u username --password-stdin
 ```
 
 ## The `ko` Model

--- a/cmd/ko/main.go
+++ b/cmd/ko/main.go
@@ -59,7 +59,7 @@ func main() {
 	authCmd.Hidden = true
 	cmds.AddCommand(authCmd)
 
-	// Just add a `ko login` command:
+	// Just add a `ko auth login` command:
 	cmds.AddCommand(cranecmd.NewCmdAuthLogin())
 
 	log.Print(Deprecation258)


### PR DESCRIPTION
`ko login` is not a valid command, it is `ko auth login`.