### PR TITLE
Use remote.WithUserAgent where possible

### DIFF
--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -54,7 +54,7 @@ func getBaseImage(platform string) build.GetBase {
 		}
 		ropt := []remote.Option{
 			remote.WithAuthFromKeychain(authn.DefaultKeychain),
-			remote.WithTransport(defaultTransport()),
+			remote.WithUserAgent(ua()),
 			remote.WithContext(ctx),
 		}
 

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
 	"path"
 	"strings"
@@ -40,29 +39,11 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func defaultTransport() http.RoundTripper {
-	return &useragentTransport{
-		inner:     http.DefaultTransport,
-		useragent: ua(),
-	}
-}
-
-type useragentTransport struct {
-	useragent string
-	inner     http.RoundTripper
-}
-
 func ua() string {
 	if v := version(); v != "" {
 		return "ko/" + v
 	}
 	return "ko"
-}
-
-// RoundTrip implements http.RoundTripper
-func (ut *useragentTransport) RoundTrip(in *http.Request) (*http.Response, error) {
-	in.Header.Set("User-Agent", ut.useragent)
-	return ut.inner.RoundTrip(in)
 }
 
 func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
@@ -178,7 +159,7 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 		}
 		if po.Push {
 			dp, err := publish.NewDefault(repoName,
-				publish.WithTransport(defaultTransport()),
+				publish.WithUserAgent(ua()),
 				publish.WithAuthFromKeychain(authn.DefaultKeychain),
 				publish.WithNamer(namer),
 				publish.WithTags(po.Tags),

--- a/pkg/publish/default.go
+++ b/pkg/publish/default.go
@@ -32,24 +32,26 @@ import (
 
 // defalt is intentionally misspelled to avoid keyword collision (and drive Jon nuts).
 type defalt struct {
-	base     string
-	t        http.RoundTripper
-	auth     authn.Authenticator
-	namer    Namer
-	tags     []string
-	insecure bool
+	base      string
+	t         http.RoundTripper
+	userAgent string
+	auth      authn.Authenticator
+	namer     Namer
+	tags      []string
+	insecure  bool
 }
 
 // Option is a functional option for NewDefault.
 type Option func(*defaultOpener) error
 
 type defaultOpener struct {
-	base     string
-	t        http.RoundTripper
-	auth     authn.Authenticator
-	namer    Namer
-	tags     []string
-	insecure bool
+	base      string
+	t         http.RoundTripper
+	userAgent string
+	auth      authn.Authenticator
+	namer     Namer
+	tags      []string
+	insecure  bool
 }
 
 // Namer is a function from a supported import path to the portion of the resulting
@@ -68,12 +70,13 @@ var defaultTags = []string{"latest"}
 
 func (do *defaultOpener) Open() (Interface, error) {
 	return &defalt{
-		base:     do.base,
-		t:        do.t,
-		auth:     do.auth,
-		namer:    do.namer,
-		tags:     do.tags,
-		insecure: do.insecure,
+		base:      do.base,
+		t:         do.t,
+		userAgent: do.userAgent,
+		auth:      do.auth,
+		namer:     do.namer,
+		tags:      do.tags,
+		insecure:  do.insecure,
 	}, nil
 }
 
@@ -81,11 +84,12 @@ func (do *defaultOpener) Open() (Interface, error) {
 // repository using the default keychain to authenticate and the default naming scheme.
 func NewDefault(base string, options ...Option) (Interface, error) {
 	do := &defaultOpener{
-		base:  base,
-		t:     http.DefaultTransport,
-		auth:  authn.Anonymous,
-		namer: identity,
-		tags:  defaultTags,
+		base:      base,
+		t:         http.DefaultTransport,
+		userAgent: "ko",
+		auth:      authn.Anonymous,
+		namer:     identity,
+		tags:      defaultTags,
 	}
 
 	for _, option := range options {
@@ -127,7 +131,7 @@ func (d *defalt) Publish(ctx context.Context, br build.Result, s string) (name.R
 	// https://github.com/google/go-containerregistry/issues/212
 	s = strings.ToLower(s)
 
-	ro := []remote.Option{remote.WithAuth(d.auth), remote.WithTransport(d.t), remote.WithContext(ctx)}
+	ro := []remote.Option{remote.WithAuth(d.auth), remote.WithTransport(d.t), remote.WithContext(ctx), remote.WithUserAgent(d.userAgent)}
 	no := []name.Option{}
 	if d.insecure {
 		no = append(no, name.Insecure)

--- a/pkg/publish/options.go
+++ b/pkg/publish/options.go
@@ -32,6 +32,15 @@ func WithTransport(t http.RoundTripper) Option {
 	}
 }
 
+// WithUserAgent is a functional option for overriding the User-Agent
+// on a default publisher.
+func WithUserAgent(ua string) Option {
+	return func(i *defaultOpener) error {
+		i.userAgent = ua
+		return nil
+	}
+}
+
 // WithAuth is a functional option for overriding the default authenticator
 // on a default publisher.
 func WithAuth(auth authn.Authenticator) Option {


### PR DESCRIPTION
This was using remote.WithTransport to set it manually, and this is much
simpler (also annotates with the go-containerregistry version). This is
really nice because it will give us at least some version information
where we had none before (for non-releases).

Before:

ko
ko/(devel)
ko/v0.7.0

After:

ko go-containerregistry/v0.4.0
ko/(devel) go-containerregistry/v0.4.0
ko/v0.7.0 go-containerregistry/v0.4.0