### PR TITLE
doc: add homebrew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ curl -L https://github.com/google/ko/releases/download/v0.7.0/ko_0.7.0_Linux_x86
 chmod +x ./ko
 ```
 
+### Install via brew
+
+If you're macOS user and using [Homebrew](https://brew.sh/), you can install via brew command:
+
+```sh
+$ brew install ko
+```
+
 ## Authenticating
 
 The `ko` CLI makes extensive use of the container registry as a ubiquitous and


### PR DESCRIPTION
relates to #296

```
==> Downloading https://homebrew.bintray.com/bottles/ko-0.7.2.mojave.bottle.tar.gz
==> Downloading from https://d29vzk4ow07wi7.cloudfront.net/16cd2e751b78b91bd6e65b8b396afbfad8ce211942adf9eb4b602c25e8a5b9df?response
######################################################################## 100.0%
==> Pouring ko-0.7.2.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/ko/0.7.2: 5 files, 35.4MB
```