### PR TITLE
support mips64le architecture.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,7 @@ builds:
   - arm64
   - s390x
   - 386
+  - mips64le
 archives:
 - replacements:
     darwin: Darwin

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ jobs:
    - arch: arm64
    - arch: s390x
    - arch: ppc64le
+   - arch: mips64le
 
 script:
   # Make sure ko compiles for the right architecture.


### PR DESCRIPTION
I am going to submit mips64le architecture，The main reasons are:
1、The mips64le architecture is also the mainstream cpu architecture (amd64, arm64), which is used by many users;
2、Golang supports cross compilation, and mips64le is officially supported;
Therefore, I hope that the release package also supports the mips64le architecture, which is convenient for more users.