### PR TITLE
Add a tag-only flag to publisher.

### DIFF
--- a/pkg/commands/options/publish.go
+++ b/pkg/commands/options/publish.go
@@ -26,6 +26,8 @@ import (
 // PublishOptions encapsulates options when publishing.
 type PublishOptions struct {
 	Tags []string
+	// TagOnly resolves images into tag-only references.
+	TagOnly bool
 
 	// Push publishes images to a registry.
 	Push bool
@@ -49,6 +51,8 @@ func AddPublishArg(cmd *cobra.Command, po *PublishOptions) {
 	cmd.Flags().StringSliceVarP(&po.Tags, "tags", "t", []string{"latest"},
 		"Which tags to use for the produced image instead of the default 'latest' tag "+
 			"(may not work properly with --base-import-paths or --bare).")
+	cmd.Flags().BoolVar(&po.TagOnly, "tag-only", false,
+		"Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.")
 
 	cmd.Flags().BoolVar(&po.Push, "push", true, "Push images to KO_DOCKER_REPO")
 

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -170,6 +170,7 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 				publish.WithAuthFromKeychain(authn.DefaultKeychain),
 				publish.WithNamer(namer),
 				publish.WithTags(po.Tags),
+				publish.WithTagOnly(po.TagOnly),
 				publish.Insecure(po.InsecureRegistry))
 			if err != nil {
 				return nil, err

--- a/pkg/publish/default_test.go
+++ b/pkg/publish/default_test.go
@@ -224,4 +224,21 @@ func TestDefaultWithReleaseTag(t *testing.T) {
 	if _, ok := createdTags["v1.2.3"]; !ok {
 		t.Errorf("Tag v1.2.3 was not created.")
 	}
+
+	def, err = NewDefault(repoName, WithTags([]string{releaseTag}), WithTagOnly(true))
+	if err != nil {
+		t.Errorf("NewDefault() = %v", err)
+	}
+	if d, err := def.Publish(context.Background(), img, build.StrictScheme+importpath); err != nil {
+		t.Errorf("Publish() = %v", err)
+	} else if !strings.HasPrefix(d.String(), repoName) {
+		t.Errorf("Publish() = %v, wanted prefix %v", d, tag.Repository)
+	} else if !strings.HasSuffix(d.Context().String(), strings.ToLower(importpath)) {
+		t.Errorf("Publish() = %v, wanted suffix %v", d.Context(), md5Hash("", importpath))
+	} else if !strings.Contains(d.String(), releaseTag) {
+		t.Errorf("Publish() = %v, wanted tag included: %v", d.String(), releaseTag)
+	} else if strings.Contains(d.String(), "@sha256:") {
+		t.Errorf("Publish() = %v, wanted no digest", d.String())
+	}
+
 }

--- a/pkg/publish/options.go
+++ b/pkg/publish/options.go
@@ -94,6 +94,14 @@ func WithTags(tags []string) Option {
 	}
 }
 
+// WithTagOnly is a functional option for resolving images into tag-only references
+func WithTagOnly(tagOnly bool) Option {
+	return func(i *defaultOpener) error {
+		i.tagOnly = tagOnly
+		return nil
+	}
+}
+
 func Insecure(b bool) Option {
 	return func(i *defaultOpener) error {
 		i.insecure = b


### PR DESCRIPTION
The `--tag-only` flag resolves images into tag-only references. This flag is useful when digests are not preserved when images are repopulated. It can only be used when a single tag is specified, and the tag is not `latest`.