### PR TITLE
Added IBM Power support (ppc64le)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,7 @@ builds:
   - s390x
   - 386
   - mips64le
+  - ppc64le
 archives:
 - replacements:
     darwin: Darwin


### PR DESCRIPTION
Added ppc64le target as it was already in travis.yml but not in the build instructions for goreleaser