### PR TITLE
Build ko for Windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,10 @@ builds:
   - -trimpath
   ldflags:
   - "-s -w -X github.com/google/ko/pkg/commands.Version={{.Version}}"
+  goos:
+  - windows
+  - linux
+  - darwin
   goarch:
   - amd64
   - arm64


### PR DESCRIPTION
Also explicitly build for macOS (darwin), I'm not sure how that was being done before.