### PR TITLE
Add support for Go build flags

### DIFF
--- a/pkg/build/config.go
+++ b/pkg/build/config.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2021 Google LLC All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import "strings"
+
+// Note: The structs, types, and functions are based upon GoReleaser build
+// configuration to have a loosely compatible YAML configuration:
+// https://github.com/goreleaser/goreleaser/blob/master/pkg/config/config.go
+
+// StringArray is a wrapper for an array of strings.
+type StringArray []string
+
+// UnmarshalYAML is a custom unmarshaler that wraps strings in arrays.
+func (a *StringArray) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var strings []string
+	if err := unmarshal(&strings); err != nil {
+		var str string
+		if err := unmarshal(&str); err != nil {
+			return err
+		}
+		*a = []string{str}
+	} else {
+		*a = strings
+	}
+	return nil
+}
+
+// FlagArray is a wrapper for an array of strings.
+type FlagArray []string
+
+// UnmarshalYAML is a custom unmarshaler that wraps strings in arrays.
+func (a *FlagArray) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var flags []string
+	if err := unmarshal(&flags); err != nil {
+		var flagstr string
+		if err := unmarshal(&flagstr); err != nil {
+			return err
+		}
+		*a = strings.Fields(flagstr)
+	} else {
+		*a = flags
+	}
+	return nil
+}
+
+// Config contains the build configuration section. The name was changed from
+// the original GoReleaser name to match better with the ko naming.
+//
+// TODO: Introduce support for more fields where possible and where it makes
+///      sense for `ko`, for example ModTimestamp, Env, or GoBinary.
+//
+type Config struct {
+	// ID only serves as an identifier internally
+	ID string `yaml:",omitempty"`
+
+	// Dir is the directory out of which the build should be triggered
+	Dir string `yaml:",omitempty"`
+
+	// Main points to the main package, or the source file with the main
+	// function, in which case only the package will be used for the importpath
+	Main string `yaml:",omitempty"`
+
+	// Ldflags and Flags will be used for the Go build command line arguments
+	Ldflags StringArray `yaml:",omitempty"`
+	Flags   FlagArray   `yaml:",omitempty"`
+
+	// Other GoReleaser fields that are not supported or do not make sense
+	// in the context of ko, for reference or for future use:
+	// Goos         []string    `yaml:",omitempty"`
+	// Goarch       []string    `yaml:",omitempty"`
+	// Goarm        []string    `yaml:",omitempty"`
+	// Gomips       []string    `yaml:",omitempty"`
+	// Targets      []string    `yaml:",omitempty"`
+	// Binary       string      `yaml:",omitempty"`
+	// Env          []string    `yaml:",omitempty"`
+	// Lang         string      `yaml:",omitempty"`
+	// Asmflags     StringArray `yaml:",omitempty"`
+	// Gcflags      StringArray `yaml:",omitempty"`
+	// ModTimestamp string      `yaml:"mod_timestamp,omitempty"`
+	// GoBinary     string      `yaml:",omitempty"`
+}

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -229,7 +229,7 @@ func TestGoBuildIsSupportedRefWithModules(t *testing.T) {
 }
 
 // A helper method we use to substitute for the default "build" method.
-func writeTempFile(_ context.Context, s string, _ string, _ v1.Platform, _ bool) (string, error) {
+func writeTempFile(_ context.Context, s string, _ string, _ v1.Platform, _ Config) (string, error) {
 	tmpDir, err := ioutil.TempDir("", "ko")
 	if err != nil {
 		return "", err

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -54,6 +54,18 @@ func WithDisabledOptimizations() Option {
 	}
 }
 
+// WithConfig is a functional option for providing GoReleaser Build influenced
+// build settings for importpaths.
+//
+// Set a fully qualified importpath (e.g. github.com/my-user/my-repo/cmd/app)
+// as the mapping key for the respective Config.
+func WithConfig(buildConfigs map[string]Config) Option {
+	return func(gbo *gobuildOpener) error {
+		gbo.buildConfigs = buildConfigs
+		return nil
+	}
+}
+
 // WithPlatforms is a functional option for building certain platforms for
 // multi-platform base images. To build everything from the base, use "all",
 // otherwise use a comma-separated list of platform specs, i.e.:

--- a/pkg/commands/config_test.go
+++ b/pkg/commands/config_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/ko/pkg/build"
 	"github.com/google/ko/pkg/commands/options"
 )
 
@@ -43,5 +44,36 @@ func TestOverrideDefaultBaseImageUsingBuildOption(t *testing.T) {
 	gotDigest := digest.String()
 	if gotDigest != wantDigest {
 		t.Errorf("got digest %s, wanted %s", gotDigest, wantDigest)
+	}
+}
+
+func TestCreateBuildConfigs(t *testing.T) {
+	compare := func(expected string, actual string) {
+		if expected != actual {
+			t.Errorf("test case failed: expected '%#v', but actual value is '%#v'", expected, actual)
+		}
+	}
+
+	buildConfigs := []build.Config{
+		{ID: "defaults"},
+		{ID: "OnlyMain", Main: "test"},
+		{ID: "OnlyMainWithFile", Main: "test/main.go"},
+		{ID: "OnlyDir", Dir: "test"},
+		{ID: "DirAndMain", Dir: "test", Main: "main.go"},
+	}
+
+	for _, b := range buildConfigs {
+		for importPath, buildCfg := range createBuildConfigs("../..", []build.Config{b}) {
+			switch buildCfg.ID {
+			case "defaults":
+				compare("github.com/google/ko", importPath)
+
+			case "OnlyMain", "OnlyMainWithFile", "OnlyDir", "DirAndMain":
+				compare("github.com/google/ko/test", importPath)
+
+			default:
+				t.Fatalf("unknown test case: %s", buildCfg.ID)
+			}
+		}
 	}
 }

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -104,6 +104,11 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 		}
 		opts = append(opts, build.WithLabel(parts[0], parts[1]))
 	}
+
+	if len(buildConfigs) > 0 {
+		opts = append(opts, build.WithConfig(buildConfigs))
+	}
+
 	return opts, nil
 }
 


### PR DESCRIPTION
Fixes #316

There are use cases, where multiple Go build flags need to be set. However, the environment variable to pass flags to Go build has some limits for `ldFlags`.

Proposed changes:
- Add GoReleaser inspired configuration section to `.ko.yaml` to support setting specific Go build and ldFlags to be used by the build.
- Add support for environment variables `KO_GOBUILD_FLAGS` to add extra build flags and `KO_GOBUILD_LDFLAGS` to add extra ldFlags.
