### PR TITLE
Use cobra's RunE wherever possible

### DIFF
--- a/pkg/commands/apply.go
+++ b/pkg/commands/apply.go
@@ -15,8 +15,8 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 
@@ -62,10 +62,9 @@ func addApply(topLevel *cobra.Command) {
   # Apply from stdin:
   cat config.yaml | ko apply -f -`,
 		Args: cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if !isKubectlAvailable() {
-				log.Print("error: kubectl is not available. kubectl must be installed to use ko apply.")
-				return
+				return errors.New("error: kubectl is not available. kubectl must be installed to use ko apply")
 			}
 
 			// Cancel on signals.
@@ -73,11 +72,11 @@ func addApply(topLevel *cobra.Command) {
 
 			builder, err := makeBuilder(ctx, bo)
 			if err != nil {
-				log.Fatalf("error creating builder: %v", err)
+				return fmt.Errorf("error creating builder: %v", err)
 			}
 			publisher, err := makePublisher(po)
 			if err != nil {
-				log.Fatalf("error creating publisher: %v", err)
+				return fmt.Errorf("error creating publisher: %v", err)
 			}
 			defer publisher.Close()
 			// Create a set of ko-specific flags to ignore when passing through
@@ -110,7 +109,7 @@ func addApply(topLevel *cobra.Command) {
 			// Wire up kubectl stdin to resolveFilesToWriter.
 			stdin, err := kubectlCmd.StdinPipe()
 			if err != nil {
-				log.Fatalf("error piping to 'kubectl apply': %v", err)
+				return fmt.Errorf("error piping to 'kubectl apply': %v", err)
 			}
 
 			// Make sure builds are cancelled if kubectl apply fails.
@@ -138,9 +137,7 @@ func addApply(topLevel *cobra.Command) {
 				return nil
 			})
 
-			if err := g.Wait(); err != nil {
-				log.Fatal(err)
-			}
+			return g.Wait()
 		},
 	}
 	options.AddPublishArg(apply, po)

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -15,8 +15,8 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 
@@ -62,10 +62,9 @@ func addCreate(topLevel *cobra.Command) {
   # Create from stdin:
   cat config.yaml | ko create -f -`,
 		Args: cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if !isKubectlAvailable() {
-				log.Print("error: kubectl is not available. kubectl must be installed to use ko create.")
-				return
+				return errors.New("error: kubectl is not available. kubectl must be installed to use ko create")
 			}
 
 			// Cancel on signals.
@@ -73,11 +72,11 @@ func addCreate(topLevel *cobra.Command) {
 
 			builder, err := makeBuilder(ctx, bo)
 			if err != nil {
-				log.Fatalf("error creating builder: %v", err)
+				return fmt.Errorf("error creating builder: %v", err)
 			}
 			publisher, err := makePublisher(po)
 			if err != nil {
-				log.Fatalf("error creating publisher: %v", err)
+				return fmt.Errorf("error creating publisher: %v", err)
 			}
 			defer publisher.Close()
 			// Create a set of ko-specific flags to ignore when passing through
@@ -110,7 +109,7 @@ func addCreate(topLevel *cobra.Command) {
 			// Wire up kubectl stdin to resolveFilesToWriter.
 			stdin, err := kubectlCmd.StdinPipe()
 			if err != nil {
-				log.Fatalf("error piping to 'kubectl create': %v", err)
+				return fmt.Errorf("error piping to 'kubectl create': %v", err)
 			}
 
 			// Make sure builds are cancelled if kubectl create fails.
@@ -138,9 +137,7 @@ func addCreate(topLevel *cobra.Command) {
 				return nil
 			})
 
-			if err := g.Wait(); err != nil {
-				log.Fatal(err)
-			}
+			return g.Wait()
 		},
 	}
 	options.AddPublishArg(create, po)

--- a/pkg/commands/publish.go
+++ b/pkg/commands/publish.go
@@ -16,7 +16,6 @@ package commands
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/google/ko/pkg/commands/options"
 	"github.com/spf13/cobra"
@@ -57,24 +56,25 @@ func addPublish(topLevel *cobra.Command) {
   # This always preserves import paths.
   ko publish --local github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah`,
 		Args: cobra.MinimumNArgs(1),
-		Run: func(_ *cobra.Command, args []string) {
+		RunE: func(_ *cobra.Command, args []string) error {
 			ctx := createCancellableContext()
 			builder, err := makeBuilder(ctx, bo)
 			if err != nil {
-				log.Fatalf("error creating builder: %v", err)
+				return fmt.Errorf("error creating builder: %v", err)
 			}
 			publisher, err := makePublisher(po)
 			if err != nil {
-				log.Fatalf("error creating publisher: %v", err)
+				return fmt.Errorf("error creating publisher: %v", err)
 			}
 			defer publisher.Close()
 			images, err := publishImages(ctx, args, publisher, builder)
 			if err != nil {
-				log.Fatalf("failed to publish images: %v", err)
+				return fmt.Errorf("failed to publish images: %v", err)
 			}
 			for _, img := range images {
 				fmt.Println(img)
 			}
+			return nil
 		},
 	}
 	options.AddPublishArg(publish, po)

--- a/pkg/commands/resolve.go
+++ b/pkg/commands/resolve.go
@@ -15,7 +15,7 @@
 package commands
 
 import (
-	"log"
+	"fmt"
 	"os"
 
 	"github.com/google/ko/pkg/commands/options"
@@ -54,20 +54,18 @@ func addResolve(topLevel *cobra.Command) {
   # This always preserves import paths.
   ko resolve --local -f config/`,
 		Args: cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := createCancellableContext()
 			builder, err := makeBuilder(ctx, bo)
 			if err != nil {
-				log.Fatalf("error creating builder: %v", err)
+				return fmt.Errorf("error creating builder: %v", err)
 			}
 			publisher, err := makePublisher(po)
 			if err != nil {
-				log.Fatalf("error creating publisher: %v", err)
+				return fmt.Errorf("error creating publisher: %v", err)
 			}
 			defer publisher.Close()
-			if err := resolveFilesToWriter(ctx, builder, publisher, fo, so, os.Stdout); err != nil {
-				log.Fatal(err)
-			}
+			return resolveFilesToWriter(ctx, builder, publisher, fo, so, os.Stdout)
 		},
 	}
 	options.AddPublishArg(resolve, po)


### PR DESCRIPTION
Notably, this makes `ko` exit 1 when `kubectl` isn't installed, instead of logging and otherwise doing nothing.

Less notably, this makes the error from `ko run` slightly less verbose.

Otherwise no functional changes are expected.