### PR TITLE
Add GitHub Action to install and setup ko

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,43 @@
+name: 'Setup ko'
+description: 'Install and authorize ko'
+branding:
+  icon: box
+  color: green
+inputs:
+  version:
+    description: 'Version of ko to install (tip, latest-release, v0.8.2, etc.)'
+    required: true
+    default: 'latest-release'
+runs:
+  using: "composite"
+  steps:
+  - shell: bash
+    run: |
+      # Install ko:
+      # - if version is "tip", install from tip of main.
+      # - if version is "latest-release", look up latest release.
+      # - otherwise, install the specified version.
+      case "${{ inputs.version }}" in
+      tip)
+        echo "Installing ko using go get"
+        go get github.com/google/ko@main
+        ;;
+      latest-release)
+        tag=$(curl -s https://api.github.com/repos/google/ko/releases/latest | jq -r '.tag_name')
+        ;;
+      *)
+        tag="${{ inputs.version }}"
+      esac
+
+      if [[ ! -z ${tag} ]]; then
+        echo "Installing ko @ ${tag}"
+        curl -fsL https://github.com/google/ko/releases/download/${tag}/ko_${tag:1}_Linux_x86_64.tar.gz | sudo tar xzf - -C /usr/local/bin ko
+      fi
+
+      # NB: username doesn't seem to matter.
+      echo "Logging in to ghcr.io"
+      echo "${{ github.token }}" | ko login ghcr.io --username "placeholder" --password-stdin
+
+      # Set KO_DOCKER_REPO for future steps.
+      echo "KO_DOCKER_REPO=ghcr.io/${{ github.repository }}"
+      echo "KO_DOCKER_REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_ENV


### PR DESCRIPTION
Example usage:

```yaml
name: Publish
on:
  push:
    branches: [ 'main' ]
jobs:
  publish:
    name: Publish
    steps:
      - uses: actions/setup-go@v2
        with:
          go-version: 1.15
      - uses: actions/checkout@v2

      - name: Setup ko
        uses: google/ko@main

      - name: Publish
        run: ko publish ./cmd/server
```

This workflow will install the latest released version of `ko` by default, `ko login ghcr.io` using the [`GITHUB_TOKEN` secret](https://docs.github.com/en/actions/reference/authentication-in-a-workflow), and set `KO_DOCKER_REPO=ghcr.io/[owner]/[repo]` for future steps, so the `ko publish` step will publish to `ghcr.io/[owner]/[repo]/server-[md5]`.

If a user wants to publish elsewhere, they can set `KO_DOCKER_REPO` themselves and provide credentials for that registry.

The action takes an input to install a specific version of `ko`:

```yaml
- name: Setup ko
  uses: google/ko@main
  with:
    version: v0.6.0
```

Users can also specify `version: tip` to build and install `ko` from the tip of the main branch using `go get`.

## A note on versioning

In general it's probably bad advice to recommend users reference the action from `@main` -- unintended breakages and possible vulnerabilities could ensue.

When included in the google/ko repo and published to the GitHub Marketplace, the action definition will be released and versioned alongside existing `ko` binary releases. This means users will be able to specify `uses: google/ko@v1.2.3` to pick up v1.2.3 _of the action definition_, even though it would by default install the floating latest release of `ko`.

I don't have a good solution to this, maybe we could try to make `uses: google/ko@v1.2.3` also install `v1.2.3` by default? Anyway I wanted to point it out as a possible cause of confusion.

-----

I've iterated on this in https://github.com/imjasonh/ghatest, where you can see an example workflow: https://github.com/imjasonh/ghatest/blob/main/.github/workflows/build.yaml

When this PR is merged, I'll delist https://github.com/marketplace/actions/setup-ko and publish google/ko's action to the GitHub Marketplace, where it will look mostly the same, with a better README.

cc @mattmoor who has some experience with GitHub Actions