### PR TITLE
Enable embedding of ko publish

### DIFF
--- a/pkg/commands/config_test.go
+++ b/pkg/commands/config_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 Google LLC All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/ko/pkg/commands/options"
+)
+
+func TestOverrideDefaultBaseImageUsingBuildOption(t *testing.T) {
+	wantDigest := "sha256:76c39a6f76890f8f8b026f89e081084bc8c64167d74e6c93da7a053cb4ccb5dd"
+	wantImage := "gcr.io/distroless/static-debian9@" + wantDigest
+	bo := &options.BuildOptions{
+		BaseImage: wantImage,
+	}
+
+	baseFn := getBaseImage("all", bo)
+	res, err := baseFn(context.Background(), "ko://example.com/helloworld")
+	if err != nil {
+		t.Fatalf("getBaseImage(): %v", err)
+	}
+
+	digest, err := res.Digest()
+	if err != nil {
+		t.Fatalf("res.Digest(): %v", err)
+	}
+	gotDigest := digest.String()
+	if gotDigest != wantDigest {
+		t.Errorf("got digest %s, wanted %s", gotDigest, wantDigest)
+	}
+}

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -22,10 +22,16 @@ import (
 
 // BuildOptions represents options for the ko builder.
 type BuildOptions struct {
+	// BaseImage enables setting the default base image programmatically.
+	// If non-empty, this takes precedence over the value in `.ko.yaml`.
+	BaseImage            string
 	ConcurrentBuilds     int
 	DisableOptimizations bool
 	Platform             string
 	Labels               []string
+	// UserAgent enables overriding the default value of the `User-Agent` HTTP
+	// request header used when retrieving the base image.
+	UserAgent string
 }
 
 func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {

--- a/pkg/commands/options/publish.go
+++ b/pkg/commands/options/publish.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Google LLC All Rights Reserved.
+Copyright 2018 Google LLC All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -34,6 +34,10 @@ type PublishOptions struct {
 
 	// LocalDomain overrides the default domain for images loaded into the local Docker daemon. Use with Local=true.
 	LocalDomain string
+
+	// UserAgent enables overriding the default value of the `User-Agent` HTTP
+	// request header used when pushing the built image to an image registry.
+	UserAgent string
 
 	Tags []string
 	// TagOnly resolves images into tag-only references.

--- a/pkg/commands/publisher.go
+++ b/pkg/commands/publisher.go
@@ -1,16 +1,18 @@
-// Copyright 2018 Google LLC All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2018 Google LLC All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package commands
 
@@ -39,6 +41,11 @@ func qualifyLocalImport(importpath string) (string, error) {
 		return "", fmt.Errorf("found %d local packages, expected 1", len(pkgs))
 	}
 	return pkgs[0].PkgPath, nil
+}
+
+// PublishImages publishes images
+func PublishImages(ctx context.Context, importpaths []string, pub publish.Interface, b build.Interface) (map[string]name.Reference, error) {
+	return publishImages(ctx, importpaths, pub, b)
 }
 
 func publishImages(ctx context.Context, importpaths []string, pub publish.Interface, b build.Interface) (map[string]name.Reference, error) {

--- a/pkg/commands/publisher_test.go
+++ b/pkg/commands/publisher_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2021 Google LLC All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/google/ko/pkg/build"
+	"github.com/google/ko/pkg/commands/options"
+)
+
+func TestPublishImages(t *testing.T) {
+	repo := "registry.example.com/repository"
+	sampleAppDir, err := sampleAppRelDir()
+	if err != nil {
+		t.Fatalf("sampleAppRelDir(): %v", err)
+	}
+	tests := []struct {
+		description string
+		publishArg  string
+		importpath  string
+	}{
+		{
+			description: "import path with ko scheme",
+			publishArg:  "ko://github.com/google/ko/test",
+			importpath:  "github.com/google/ko/test",
+		},
+		{
+			description: "import path without ko scheme",
+			publishArg:  "github.com/google/ko/test",
+			importpath:  "github.com/google/ko/test",
+		},
+		{
+			description: "file path",
+			publishArg:  sampleAppDir,
+			importpath:  "github.com/google/ko/test",
+		},
+	}
+	for _, test := range tests {
+		ctx := context.Background()
+		bo := &options.BuildOptions{
+			ConcurrentBuilds: 1,
+		}
+		builder, err := NewBuilder(ctx, bo)
+		if err != nil {
+			t.Fatalf("%s: MakeBuilder(): %v", test.description, err)
+		}
+		po := &options.PublishOptions{
+			DockerRepo:          repo,
+			PreserveImportPaths: true,
+		}
+		publisher, err := NewPublisher(po)
+		if err != nil {
+			t.Fatalf("%s: MakePublisher(): %v", test.description, err)
+		}
+		importpathWithScheme := build.StrictScheme + test.importpath
+		refs, err := PublishImages(ctx, []string{test.publishArg}, publisher, builder)
+		if err != nil {
+			t.Fatalf("%s: PublishImages(): %v", test.description, err)
+		}
+		ref, exists := refs[importpathWithScheme]
+		if !exists {
+			t.Errorf("%s: could not find image for importpath %s", test.description, importpathWithScheme)
+		}
+		gotImageName := ref.Context().Name()
+		wantImageName := strings.ToLower(fmt.Sprintf("%s/%s", repo, test.importpath))
+		if gotImageName != wantImageName {
+			t.Errorf("%s: got %s, wanted %s", test.description, gotImageName, wantImageName)
+		}
+	}
+}
+
+func sampleAppRelDir() (string, error) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("could not get current filename")
+	}
+	basepath := filepath.Dir(filename)
+	testAppDir := filepath.Join(basepath, "..", "..", "test")
+	return filepath.Rel(basepath, testAppDir)
+}


### PR DESCRIPTION
Enable embedding of ko's `publish` functionality to be in other tools.

- Export `MakeBuilder()`, `MakePublisher()` and `PublishImages()` from `pkg/commands`
- Allow overriding `UserAgent()`
- Add `DockerRepo` flag to `PublishOptions` in `pkg/commands/options`

See https://github.com/GoogleContainerTools/skaffold/pull/5611