### PR TITLE
Add flag and PublishOption for destination repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,16 @@ to
 
 ## Choose Destination
 
-`ko` depends on an environment variable, `KO_DOCKER_REPO`, to identify where it
-should push images that it builds. Typically this will be a remote registry,
-e.g.:
+`ko` must be configured with a destination for where it should push images that
+it builds. You can configure this with either the `--docker-repo` flag or the
+`KO_DOCKER_REPO` environment variable. Typically, the value will be a remote
+registry, e.g.:
 
 - `KO_DOCKER_REPO=gcr.io/my-project`, or
-- `KO_DOCKER_REPO=my-dockerhub-user`
+- `--docker-repo=my-dockerhub-user`
+
+If both the flag and the environment variable are set, the flag value takes
+precedence.
 
 # Build an Image
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,6 @@ e.g.:
 - `KO_DOCKER_REPO=gcr.io/my-project`, or
 - `KO_DOCKER_REPO=my-dockerhub-user`
 
-If both the flag and the environment variable are set, the flag value takes
-precedence.
-
 # Build an Image
 
 `ko publish ./cmd/app` builds and pushes a container image, and prints the

--- a/README.md
+++ b/README.md
@@ -61,13 +61,12 @@ to
 
 ## Choose Destination
 
-`ko` must be configured with a destination for where it should push images that
-it builds. You can configure this with either the `--docker-repo` flag or the
-`KO_DOCKER_REPO` environment variable. Typically, the value will be a remote
-registry, e.g.:
+`ko` depends on an environment variable, `KO_DOCKER_REPO`, to identify where it
+should push images that it builds. Typically this will be a remote registry,
+e.g.:
 
 - `KO_DOCKER_REPO=gcr.io/my-project`, or
-- `--docker-repo=my-dockerhub-user`
+- `KO_DOCKER_REPO=my-dockerhub-user`
 
 If both the flag and the environment variable are set, the flag value takes
 precedence.

--- a/pkg/commands/options/publish.go
+++ b/pkg/commands/options/publish.go
@@ -1,16 +1,18 @@
-// Copyright 2021 Google LLC All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2021 Google LLC All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package options
 
@@ -26,7 +28,8 @@ import (
 
 // PublishOptions encapsulates options when publishing.
 type PublishOptions struct {
-	// DockerRepo configures the destination image repository
+	// DockerRepo configures the destination image repository.
+	// In normal ko usage, this is populated with the value of $KO_DOCKER_REPO.
 	DockerRepo string
 
 	Tags []string

--- a/pkg/commands/options/publish.go
+++ b/pkg/commands/options/publish.go
@@ -17,6 +17,7 @@ package options
 import (
 	"crypto/md5" //nolint: gosec // No strong cryptography needed.
 	"encoding/hex"
+	"os"
 	"path"
 
 	"github.com/google/ko/pkg/publish"
@@ -49,7 +50,11 @@ type PublishOptions struct {
 }
 
 func AddPublishArg(cmd *cobra.Command, po *PublishOptions) {
-	cmd.Flags().StringVar(&po.DockerRepo, "docker-repo", "", "Repository to push images, overrides KO_DOCKER_REPO")
+	// Set DockerRepo from the KO_DOCKER_REPO envionment variable.
+	// See https://github.com/google/ko/pull/351 for flag discussion.
+	if dockerRepo, exists := os.LookupEnv("KO_DOCKER_REPO"); exists {
+		po.DockerRepo = dockerRepo
+	}
 
 	cmd.Flags().StringSliceVarP(&po.Tags, "tags", "t", []string{"latest"},
 		"Which tags to use for the produced image instead of the default 'latest' tag "+

--- a/pkg/commands/options/publish.go
+++ b/pkg/commands/options/publish.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC All Rights Reserved.
+// Copyright 2021 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,9 @@ import (
 
 // PublishOptions encapsulates options when publishing.
 type PublishOptions struct {
+	// DockerRepo overrides the KO_DOCKER_REPO environment variable, if present
+	DockerRepo string
+
 	Tags []string
 
 	// Push publishes images to a registry.
@@ -46,6 +49,8 @@ type PublishOptions struct {
 }
 
 func AddPublishArg(cmd *cobra.Command, po *PublishOptions) {
+	cmd.Flags().StringVar(&po.DockerRepo, "docker-repo", "", "Repository to push images, overrides KO_DOCKER_REPO")
+
 	cmd.Flags().StringSliceVarP(&po.Tags, "tags", "t", []string{"latest"},
 		"Which tags to use for the produced image instead of the default 'latest' tag "+
 			"(may not work properly with --base-import-paths or --bare).")

--- a/pkg/commands/options/publish.go
+++ b/pkg/commands/options/publish.go
@@ -26,7 +26,7 @@ import (
 
 // PublishOptions encapsulates options when publishing.
 type PublishOptions struct {
-	// DockerRepo overrides the KO_DOCKER_REPO environment variable, if present
+	// DockerRepo configures the destination image repository
 	DockerRepo string
 
 	Tags []string

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC All Rights Reserved.
+// Copyright 2021 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -132,6 +132,9 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 	// to either a docker daemon or a container image registry.
 	innerPublisher, err := func() (publish.Interface, error) {
 		repoName := os.Getenv("KO_DOCKER_REPO")
+		if po.DockerRepo != "" {
+			repoName = po.DockerRepo
+		}
 		namer := options.MakeNamer(po)
 		if repoName == publish.LocalDomain || po.Local {
 			// TODO(jonjohnsonjr): I'm assuming that nobody will
@@ -144,7 +147,7 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 		}
 
 		if repoName == "" {
-			return nil, errors.New("KO_DOCKER_REPO environment variable is unset")
+			return nil, errors.New("either --docker-repo flag or KO_DOCKER_REPO environment variable must be set")
 		}
 		if _, err := name.NewRegistry(repoName); err != nil {
 			if _, err := name.NewRepository(repoName); err != nil {

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -1,16 +1,18 @@
-// Copyright 2021 Google LLC All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2021 Google LLC All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package commands
 

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -131,10 +131,7 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 	// Create the publish.Interface that we will use to publish image references
 	// to either a docker daemon or a container image registry.
 	innerPublisher, err := func() (publish.Interface, error) {
-		repoName := os.Getenv("KO_DOCKER_REPO")
-		if po.DockerRepo != "" {
-			repoName = po.DockerRepo
-		}
+		repoName := po.DockerRepo
 		namer := options.MakeNamer(po)
 		if repoName == publish.LocalDomain || po.Local {
 			// TODO(jonjohnsonjr): I'm assuming that nobody will
@@ -147,7 +144,7 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 		}
 
 		if repoName == "" {
-			return nil, errors.New("either --docker-repo flag or KO_DOCKER_REPO environment variable must be set")
+			return nil, errors.New("KO_DOCKER_REPO environment variable is unset")
 		}
 		if _, err := name.NewRegistry(repoName); err != nil {
 			if _, err := name.NewRepository(repoName); err != nil {


### PR DESCRIPTION
This enables programmatically setting the destination image repository
when embedding ko's `publish` functionality in other tools.

See discussion in https://github.com/google/ko/pull/348 for additional context.