### PR TITLE
Enable override of daemon publisher local domain

### DIFF
--- a/pkg/commands/options/publish.go
+++ b/pkg/commands/options/publish.go
@@ -32,6 +32,9 @@ type PublishOptions struct {
 	// In normal ko usage, this is populated with the value of $KO_DOCKER_REPO.
 	DockerRepo string
 
+	// LocalDomain overrides the default domain for images loaded into the local Docker daemon. Use with Local=true.
+	LocalDomain string
+
 	Tags []string
 
 	// Push publishes images to a registry.

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -139,7 +139,10 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 			// TODO(jonjohnsonjr): I'm assuming that nobody will
 			// use local with other publishers, but that might
 			// not be true.
-			return publish.NewDaemon(namer, po.Tags), nil
+			return publish.NewDaemon(namer,
+				publish.WithLocalDomain(po.LocalDomain),
+				publish.WithLocalTags(po.Tags),
+			)
 		}
 		if repoName == publish.KindDomain {
 			return publish.NewKindPublisher(namer, po.Tags), nil

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -139,10 +139,8 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 			// TODO(jonjohnsonjr): I'm assuming that nobody will
 			// use local with other publishers, but that might
 			// not be true.
-			return publish.NewDaemon(namer,
-				publish.WithLocalDomain(po.LocalDomain),
-				publish.WithLocalTags(po.Tags),
-			)
+			return publish.NewDaemon(namer, po.Tags,
+				publish.WithLocalDomain(po.LocalDomain))
 		}
 		if repoName == publish.KindDomain {
 			return publish.NewKindPublisher(namer, po.Tags), nil

--- a/pkg/publish/daemon.go
+++ b/pkg/publish/daemon.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Google LLC All Rights Reserved.
+Copyright 2018 Google LLC All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -54,20 +54,12 @@ func WithLocalDomain(domain string) DaemonOption {
 	}
 }
 
-// WithTags is a functional option for overriding the image tags
-func WithLocalTags(tags []string) DaemonOption {
-	return func(i *demon) error {
-		i.tags = tags
-		return nil
-	}
-}
-
 // NewDaemon returns a new publish.Interface that publishes images to a container daemon.
-func NewDaemon(namer Namer, opts ...DaemonOption) (Interface, error) {
+func NewDaemon(namer Namer, tags []string, opts ...DaemonOption) (Interface, error) {
 	d := &demon{
 		base:  LocalDomain,
 		namer: namer,
-		tags:  []string{},
+		tags:  tags,
 	}
 	for _, option := range opts {
 		if err := option(d); err != nil {

--- a/pkg/publish/daemon_test.go
+++ b/pkg/publish/daemon_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Google LLC All Rights Reserved.
+Copyright 2018 Google LLC All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ func TestDaemon(t *testing.T) {
 		t.Fatalf("random.Image() = %v", err)
 	}
 
-	def, err := NewDaemon(md5Hash)
+	def, err := NewDaemon(md5Hash, []string{})
 	if err != nil {
 		t.Fatalf("NewDaemon() = %v", err)
 	}
@@ -83,7 +83,7 @@ func TestDaemonTags(t *testing.T) {
 		t.Fatalf("random.Image() = %v", err)
 	}
 
-	def, err := NewDaemon(md5Hash, WithLocalTags([]string{"v2.0.0", "v1.2.3", "production"}))
+	def, err := NewDaemon(md5Hash, []string{"v2.0.0", "v1.2.3", "production"})
 	if err != nil {
 		t.Fatalf("NewDaemon() = %v", err)
 	}
@@ -113,9 +113,7 @@ func TestDaemonDomain(t *testing.T) {
 	}
 
 	localDomain := "registry.example.com/repository"
-	def, err := NewDaemon(md5Hash,
-		WithLocalDomain(localDomain),
-		WithLocalTags([]string{"v1.0.0"}))
+	def, err := NewDaemon(md5Hash, []string{}, WithLocalDomain(localDomain))
 	if err != nil {
 		t.Fatalf("NewDaemon() = %v", err)
 	}


### PR DESCRIPTION
Add a `LocalDomain` field to `PublishOptions`, but no flag (yet?).

This allows use of a domain (base repo) other than `ko.local` for images
that are side-loaded to the local Docker daemon.

An alternative implementation would be to add a boolean field that
indicates that `ko publish` should use the value of the `KO_DOCKER_REPO`
environment variable (or the `DockerRepo` field in `PublishOptions`) as
the base name for images side-loaded to the local Docker daemon. I'd be
happy to get feedback on which option would work best.