### PR TITLE
Add KO_DATA_DATE_EPOCH env var to set the modification time for files in `kodata`

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,13 @@ you can include Git commit information in your image with:
 ln -s -r .git/HEAD ./cmd/app/kodata/
 ```
 
+Also note that `http.FileServer` will not serve the `Last-Modified` header
+(or validate `If-Modified-Since` request headers) because `ko` does not embed
+timestamps by default.
+
+This can be supported by manually setting the `KO_DATA_DATE_EPOCH` environment
+variable during build ([See below](#Why-are-my-images-all-created-in-1970)).
+
 # Kubernetes Integration
 
 You could stop at just building and pushing images.
@@ -335,24 +342,28 @@ GOFLAGS="-ldflags=-X=main.version=1.2.3" ko publish .
 ## Why are my images all created in 1970?
 
 In order to support [reproducible builds](https://reproducible-builds.org), `ko`
-doesn't embed timestamps in the images it produces by default; however, `ko`
-does respect the
-[`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/)
-environment variable.
+doesn't embed timestamps in the images it produces by default.
 
-For example, you can set this to the current timestamp by executing:
+However, `ko` does respect the [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/)
+environment variable, which will set the container image's timestamp
+accordingly.
+
+Similarly, the `KO_DATA_DATE_EPOCH` environment variable can be used to set
+the _modtime_ timestamp of the files in `KO_DATA_PATH`.
+
+For example, you can set the container image's timestamp to the current
+timestamp by executing:
 
 ```
 export SOURCE_DATE_EPOCH=$(date +%s)
 ```
 
-or to the latest git commit's timestamp with:
+or set the timestamp of the files in `KO_DATA_PATH` to the latest git commit's
+timestamp with:
 
 ```
-export SOURCE_DATE_EPOCH=$(git log -1 --format='%ct')
+export KO_DATA_DATE_EPOCH=$(git log -1 --format='%ct')
 ```
-
-The same applies to `KO_DATA_DATE_EPOCH` which sets the last modified time of all files in `kodata`.
 
 ## Can I optimize images for [eStargz support](https://github.com/containerd/stargz-snapshotter/blob/v0.2.0/docs/stargz-estargz.md)?
 

--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ or to the latest git commit's timestamp with:
 export SOURCE_DATE_EPOCH=$(git log -1 --format='%ct')
 ```
 
+The same applies to `KO_DATA_DATE_EPOCH` which sets the last modified time of all files in `kodata`.
+
 ## Can I optimize images for [eStargz support](https://github.com/containerd/stargz-snapshotter/blob/v0.2.0/docs/stargz-estargz.md)?
 
 Yes! Set the environment variable `GGCR_EXPERIMENT_ESTARGZ=1` to produce

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -36,6 +36,15 @@ func WithCreationTime(t v1.Time) Option {
 	}
 }
 
+// WithKoDataCreationTime is a functional option for overriding the creation
+// time given to the files in the kodata directory.
+func WithKoDataCreationTime(t v1.Time) Option {
+	return func(gbo *gobuildOpener) error {
+		gbo.kodataCreationTime = t
+		return nil
+	}
+}
+
 // WithDisabledOptimizations is a functional option for disabling optimizations
 // when compiling.
 func WithDisabledOptimizations() Option {

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -127,17 +127,25 @@ func getBaseImage(platform string, bo *options.BuildOptions) build.GetBase {
 	}
 }
 
-func getCreationTime() (*v1.Time, error) {
-	epoch := os.Getenv("SOURCE_DATE_EPOCH")
+func getTimeFromEnv(env string) (*v1.Time, error) {
+	epoch := os.Getenv(env)
 	if epoch == "" {
 		return nil, nil
 	}
 
 	seconds, err := strconv.ParseInt(epoch, 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("the environment variable SOURCE_DATE_EPOCH should be the number of seconds since January 1st 1970, 00:00 UTC, got: %v", err)
+		return nil, fmt.Errorf("the environment variable %s should be the number of seconds since January 1st 1970, 00:00 UTC, got: %v", env, err)
 	}
 	return &v1.Time{Time: time.Unix(seconds, 0)}, nil
+}
+
+func getCreationTime() (*v1.Time, error) {
+	return getTimeFromEnv("SOURCE_DATE_EPOCH")
+}
+
+func getKoDataCreationTime() (*v1.Time, error) {
+	return getTimeFromEnv("KO_DATA_DATE_EPOCH")
 }
 
 func createCancellableContext() context.Context {

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -55,6 +55,11 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 		return nil, err
 	}
 
+	kodataCreationTime, err := getKoDataCreationTime()
+	if err != nil {
+		return nil, err
+	}
+
 	platform := bo.Platform
 	if platform == "" {
 		platform = "linux/amd64"
@@ -85,6 +90,9 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 	}
 	if creationTime != nil {
 		opts = append(opts, build.WithCreationTime(*creationTime))
+	}
+	if kodataCreationTime != nil {
+		opts = append(opts, build.WithKoDataCreationTime(*kodataCreationTime))
 	}
 	if bo.DisableOptimizations {
 		opts = append(opts, build.WithDisabledOptimizations())


### PR DESCRIPTION
Example:

```sh
export KO_DATA_DATE_EPOCH=$(git log -1 --format='%ct')
ko publish .
```

This allows static file servers mounted at `KO_DATA_PATH` to send the `Last-Modified` header and handle revalidation requests.