### PR TITLE
Update "go install" instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ brew install ko
 With Go 1.16+, build and install the latest released version:
 
 ```
-go install github.com/google/ko
+go install github.com/google/ko@latest
 ```
 
 ## Authenticate


### PR DESCRIPTION
I got the following error when following the original instructions:

    go install: version is required when current directory is not in a module
            Try 'go install github.com/google/ko@latest' to install the latest version