### PR TITLE
Enable overriding docker client

### DIFF
--- a/pkg/commands/options/publish.go
+++ b/pkg/commands/options/publish.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/google/go-containerregistry/pkg/v1/daemon"
 	"github.com/google/ko/pkg/publish"
 	"github.com/spf13/cobra"
 )
@@ -38,6 +39,11 @@ type PublishOptions struct {
 	// UserAgent enables overriding the default value of the `User-Agent` HTTP
 	// request header used when pushing the built image to an image registry.
 	UserAgent string
+
+	// DockerClient enables overriding the default docker client when embedding
+	// ko as a module in other tools.
+	// If left as the zero value, ko uses github.com/docker/docker/client.FromEnv
+	DockerClient daemon.Client
 
 	Tags []string
 	// TagOnly resolves images into tag-only references.

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -164,7 +164,9 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 			// use local with other publishers, but that might
 			// not be true.
 			return publish.NewDaemon(namer, po.Tags,
-				publish.WithLocalDomain(po.LocalDomain))
+				publish.WithDockerClient(po.DockerClient),
+				publish.WithLocalDomain(po.LocalDomain),
+			)
 		}
 		if repoName == publish.KindDomain {
 			return publish.NewKindPublisher(namer, po.Tags), nil

--- a/pkg/publish/daemon_test.go
+++ b/pkg/publish/daemon_test.go
@@ -46,15 +46,6 @@ func (m *mockClient) ImageTag(_ context.Context, _ string, tag string) error {
 
 var Tags []string
 
-func init() {
-	getOpts = func(ctx context.Context) []daemon.Option {
-		return []daemon.Option{
-			daemon.WithContext(ctx),
-			daemon.WithClient(&mockClient{}),
-		}
-	}
-}
-
 func TestDaemon(t *testing.T) {
 	importpath := "github.com/google/ko"
 	img, err := random.Image(1024, 1)
@@ -62,7 +53,7 @@ func TestDaemon(t *testing.T) {
 		t.Fatalf("random.Image() = %v", err)
 	}
 
-	def, err := NewDaemon(md5Hash, []string{})
+	def, err := NewDaemon(md5Hash, []string{}, WithDockerClient(&mockClient{}))
 	if err != nil {
 		t.Fatalf("NewDaemon() = %v", err)
 	}
@@ -83,7 +74,7 @@ func TestDaemonTags(t *testing.T) {
 		t.Fatalf("random.Image() = %v", err)
 	}
 
-	def, err := NewDaemon(md5Hash, []string{"v2.0.0", "v1.2.3", "production"})
+	def, err := NewDaemon(md5Hash, []string{"v2.0.0", "v1.2.3", "production"}, WithDockerClient(&mockClient{}))
 	if err != nil {
 		t.Fatalf("NewDaemon() = %v", err)
 	}
@@ -113,7 +104,7 @@ func TestDaemonDomain(t *testing.T) {
 	}
 
 	localDomain := "registry.example.com/repository"
-	def, err := NewDaemon(md5Hash, []string{}, WithLocalDomain(localDomain))
+	def, err := NewDaemon(md5Hash, []string{}, WithLocalDomain(localDomain), WithDockerClient(&mockClient{}))
 	if err != nil {
 		t.Fatalf("NewDaemon() = %v", err)
 	}


### PR DESCRIPTION
When embedding ko, it may be necessary to override the docker client.

This adds a PublishOption to inject a docker client created elsewhere.
Ko will use this client to interact with the docker daemon.

Context: https://github.com/GoogleContainerTools/skaffold/pull/6054#discussion_r662230195