### PR TITLE
make ko environment variables aware while resolving YAML files

### DIFF
--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -432,7 +432,7 @@ func resolveFile(
 	// The loop is to support multi-document yaml files.
 	// This is handled by using a yaml.Decoder and reading objects until io.EOF, see:
 	// https://godoc.org/gopkg.in/yaml.v3#Decoder.Decode
-	decoder := yaml.NewDecoder(bytes.NewBuffer(b))
+	decoder := yaml.NewDecoder(bytes.NewBuffer([]byte(os.ExpandEnv(string(b)))))
 	for {
 		var doc yaml.Node
 		if err := decoder.Decode(&doc); err != nil {


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

Let's assume that I have a YAML file that includes some environment variables, and I want to resolve my YAML file using ko's resolve sub-command.

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: falco-event-listener
  namespace: falco
  labels:
    app: falco-event-listener
spec:
  containers:
  - image: ko://github.com/developer-guy/falco-event-listener
    name: falco-event-listener
    args:
      - "--notify-url"
      - "http://receiver.flux-system/$(WEBHOOK_URL)"
    env:
      - name: WEBHOOK_URL
        value: $WEBHOOK_URL
```
As you can see, I have some environment variables defined in the YAML file. Before running the following command I defined the `WEBHOOK_URL` environment variable in my shell session:

```shell
$ export WEBHOOK_URL="somerandomurl"
$ ko resolve -f listener.yaml
2021/07/04 18:24:59 NOTICE!
-----------------------------------------------------------------
ko and go have mismatched GOROOT:
    go/build.Default.GOROOT = "go"
    $(go env GOROOT) = "/usr/local/Cellar/go/1.16.5/libexec"

Inferring GOROOT="/usr/local/Cellar/go/1.16.5/libexec"

Run this to remove this warning:
    export GOROOT=$(go env GOROOT)

For more information see:
    https://github.com/google/ko/issues/106
apiVersion: v1
kind: Pod
metadata:
  name: falco-event-listener
  namespace: falco
  labels:
    app: falco-event-listener
spec:
  containers:
    - image: gcr.io/developerguy-311909/falco-event-listener-355c83b3413baa4dc0f62f21c3a83388@sha256:a21798867709e562b969ea16307c03e4a7d1a45f2dc58e9a32e4732984653a10
      name: falco-event-listener
      args:
        - "--notify-url"
        - "http://receiver.flux-system/$(WEBHOOK_URL)"
      env:
        - name: WEBHOOK_URL
          value: $WEBHOOK_URL
```
As you can see from the above output, the variable remains the same, so nothing changed. This PR aims to solve this problem.

> ko version: 0.83
> environment: Darwin xxxx 19.6.0 Darwin Kernel Version 19.6.0: Thu May  6 00:48:39 PDT 2021; root:xnu-6153.141.33~1/RELEASE_X86_64 x86_64