### PR TITLE
Fix layout tests on macos

### DIFF
--- a/pkg/publish/layout_test.go
+++ b/pkg/publish/layout_test.go
@@ -31,7 +31,7 @@ func TestLayout(t *testing.T) {
 	}
 	importpath := "github.com/Google/go-containerregistry/cmd/crane"
 
-	tmp, err := ioutil.TempDir("", "ko")
+	tmp, err := ioutil.TempDir("/tmp", "ko")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/publish/multi_test.go
+++ b/pkg/publish/multi_test.go
@@ -42,7 +42,7 @@ func TestMulti(t *testing.T) {
 
 	tp := NewTarball(fp.Name(), repoName, md5Hash, []string{})
 
-	tmp, err := ioutil.TempDir("", "ko")
+	tmp, err := ioutil.TempDir("/tmp", "ko")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes https://github.com/google/ko/issues/256

The default temp dir on macos is something like `/var/folders/bb/l0yfqc6d6kb5zm5f9ktyx0nw0000gn/T/ko299660247`, which  results in error messages like:

```
    layout_test.go:45: Publish() = repository can only contain the runes `abcdefghijklmnopqrstuvwxyz0123456789_-./`: /var/folders/bb/l0yfqc6d6kb5zm5f9ktyx0nw0000gn/T/ko299660247
```

By forcing the temp dir into `/tmp`, we make sure we generate a valid repository.