### PR TITLE
Silence usage report on internal errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,8 +33,9 @@ func main() {
 
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
-		Use:   "ko",
-		Short: "Rapidly iterate with Go, Containers, and Kubernetes.",
+		Use:          "ko",
+		Short:        "Rapidly iterate with Go, Containers, and Kubernetes.",
+		SilenceUsage: true, // Don't show usage on errors
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Help()
 		},


### PR DESCRIPTION
See https://github.com/spf13/cobra/issues/340 for why this isn't the default (answer: historically, it wasn't the default, and spf13 is trying not to break people).
