### PR TITLE
Make --insecure-registry work with TLS registries whose certs we can't verify.

### DIFF
--- a/pkg/publish/options.go
+++ b/pkg/publish/options.go
@@ -16,7 +16,6 @@ package publish
 
 import (
 	"crypto/tls"
-	"fmt"
 	"log"
 	"net/http"
 	"path"
@@ -109,7 +108,7 @@ func Insecure(b bool) Option {
 		i.insecure = b
 		t, ok := i.t.(*http.Transport)
 		if !ok {
-			return fmt.Errorf("unable to configure insecure roundtripper (not HTTP)")
+			return nil
 		}
 		t = t.Clone()
 		if t.TLSClientConfig == nil {

--- a/pkg/publish/options.go
+++ b/pkg/publish/options.go
@@ -15,6 +15,8 @@
 package publish
 
 import (
+	"crypto/tls"
+	"fmt"
 	"log"
 	"net/http"
 	"path"
@@ -105,6 +107,17 @@ func WithTagOnly(tagOnly bool) Option {
 func Insecure(b bool) Option {
 	return func(i *defaultOpener) error {
 		i.insecure = b
+		t, ok := i.t.(*http.Transport)
+		if !ok {
+			return fmt.Errorf("unable to configure insecure roundtripper (not HTTP)")
+		}
+		t = t.Clone()
+		if t.TLSClientConfig == nil {
+			t.TLSClientConfig = &tls.Config{} //nolint: gosec
+		}
+		t.TLSClientConfig.InsecureSkipVerify = b //nolint: gosec
+		i.t = t
+
 		return nil
 	}
 }


### PR DESCRIPTION
Fixes #396

Note that this is technically breaking if people are using --insecure-registry and replacing the RoundTripper with something that's not an `http.Transport`. I decided to blow up loudly, rather than let it pass, but I could be convinced to go the other way.

Verified on harbor 2.2.3 with a self-signed cert with a SAN of 192.168.10.12.
