### PR TITLE
Run integration_test.sh with Go 1.16

### DIFF
--- a/.github/workflows/modules-integration-test.yaml
+++ b/.github/workflows/modules-integration-test.yaml
@@ -5,28 +5,19 @@ on:
     branches: ['main']
 
 jobs:
-
   test:
     name: Module Tests
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
-        platform: [ubuntu-latest]
-
-    runs-on: ${{ matrix.platform }}
+        go-version: [1.14.x, 1.15.x, 1.16.x]
+    runs-on: ubuntu-latest
 
     steps:
-
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
-        id: go
-
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Test
-        env:
+      - uses: actions/checkout@v2
+      - env:
           GOPATH: does not matter
         run: ./integration_test.sh

--- a/.github/workflows/modules-integration-test.yaml
+++ b/.github/workflows/modules-integration-test.yaml
@@ -8,6 +8,7 @@ jobs:
   test:
     name: Module Tests
     strategy:
+      fail-fast: false
       matrix:
         go-version: [1.14.x, 1.15.x, 1.16.x]
     runs-on: ubuntu-latest

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -20,7 +20,7 @@ mkdir -p "$GOPATH/src/github.com/google/ko"
 cp -r "$ROOT_DIR/"* "$GOPATH/src/github.com/google/ko/"
 
 echo "Downloading github.com/go-training/helloworld"
-go get -d github.com/go-training/helloworld
+GO111MODULE=off go get -d github.com/go-training/helloworld
 
 pushd "$GOPATH/src/github.com/google/ko" || exit 1
 


### PR DESCRIPTION
I think this might break for 1.16...

(Also simplify the workflow yaml; the only relevant change is to the `go-version` matrix values)