### PR TITLE
Enable setting environment variables in .ko.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ configuration section in your `.ko.yaml`.
 builds:
 - id: foo
   main: ./foobar/foo
+  env:
+  - GOPRIVATE=git.internal.example.com,source.developers.google.com
   flags:
   - -tags
   - netgo
@@ -144,6 +146,8 @@ builds:
   - -X main.version={{.Env.VERSION}}
 - id: bar
   main: ./foobar/bar/main.go
+  env:
+  - CGO_ENABLED=1
   ldflags:
   - -s
   - -w
@@ -156,7 +160,7 @@ with the intended import path.
 
 _Please note:_ Even though the configuration section is similar to the
 [GoReleaser `builds` section](https://goreleaser.com/customization/build/),
-only the `flags` and `ldflags` fields are currently supported. Also, the
+only the `env`, `flags` and `ldflags` fields are currently supported. Also, the
 templating support is currently limited to environment variables only.
 
 ## Naming Images

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ builds:
 - id: bar
   main: ./foobar/bar/main.go
   env:
-  - CGO_ENABLED=1
+  - GOCACHE=/workspace/.gocache
   ldflags:
   - -s
   - -w

--- a/pkg/build/config.go
+++ b/pkg/build/config.go
@@ -79,6 +79,9 @@ type Config struct {
 	Ldflags StringArray `yaml:",omitempty"`
 	Flags   FlagArray   `yaml:",omitempty"`
 
+	// Env allows setting environment variables for `go build`
+	Env []string `yaml:",omitempty"`
+
 	// Other GoReleaser fields that are not supported or do not make sense
 	// in the context of ko, for reference or for future use:
 	// Goos         []string    `yaml:",omitempty"`
@@ -87,7 +90,6 @@ type Config struct {
 	// Gomips       []string    `yaml:",omitempty"`
 	// Targets      []string    `yaml:",omitempty"`
 	// Binary       string      `yaml:",omitempty"`
-	// Env          []string    `yaml:",omitempty"`
 	// Lang         string      `yaml:",omitempty"`
 	// Asmflags     StringArray `yaml:",omitempty"`
 	// Gcflags      StringArray `yaml:",omitempty"`


### PR DESCRIPTION
Matches the GoReleaser format.

Related: #340