### PR TITLE
Speed up base image unit test with local registry

### DIFF
--- a/pkg/commands/resolver_test.go
+++ b/pkg/commands/resolver_test.go
@@ -166,6 +166,7 @@ func TestNewBuilder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create test registry server: %v", err)
 	}
+	defer s.Close()
 	baseImage := fmt.Sprintf("%s/%s", s.Listener.Addr().String(), namespace)
 
 	tests := []struct {


### PR DESCRIPTION
Also follow my own advice to `defer Close()` :innocent: