### PR TITLE
Bump to Go 1.16.x

### DIFF
--- a/.github/workflows/modules-integration-test.yaml
+++ b/.github/workflows/modules-integration-test.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Module Tests
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.16.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/ko
 
-go 1.15
+go 1.16
 
 require (
 	github.com/containerd/stargz-snapshotter/estargz v0.8.0

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -20,7 +20,7 @@ mkdir -p "$GOPATH/src/github.com/google/ko"
 cp -r "$ROOT_DIR/"* "$GOPATH/src/github.com/google/ko/"
 
 echo "Downloading github.com/go-training/helloworld"
-go get -d github.com/go-training/helloworld
+GO111MODULE=off go get -d github.com/go-training/helloworld
 
 pushd "$GOPATH/src/github.com/google/ko" || exit 1
 


### PR DESCRIPTION
Go 1.16 introduces "embed", which folks are starting to adopt.

Folks are also starting to use things from `io` instead of `ioutil`, which is another 1.16 change I've seen folks picking up without even realizing it.