### PR TITLE
Update OpenShift instructions to point to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,14 +458,14 @@ Yes! `ko resolve -f -` will read and process input from stdin, so you can have
 kustomize build config | ko resolve -f -
 ```
 
-## Does `ko` work with [OpenShift Internal Registry](https://docs.openshift.com/container-platform/4.7/registry/registry-options.html#registry-integrated-openshift-registry_registry-options)?
+## Does `ko` work with [OpenShift Internal Registry](https://docs.openshift.com/container-platform/latest/registry/registry-options.html#registry-integrated-openshift-registry_registry-options)?
 
 Yes! Follow these steps:
 
 - Connect to your OpenShift installation:
-  https://docs.openshift.com/container-platform/4.7/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands
+  https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands
 - Expose the OpenShift Internal Registry so you can push to it:
-  https://docs.openshift.com/container-platform/4.7/registry/securing-exposing-registry.html
+  https://docs.openshift.com/container-platform/latest/registry/securing-exposing-registry.html
 - Export your token to `$HOME/.docker/config.json`:
 
 ```sh
@@ -477,7 +477,7 @@ oc registry login --to=$HOME/.docker/config.json
   registry.
 
 ```sh
-   export KO_DOCKER_REPO=$(oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}')/ko-images
+   export KO_DOCKER_REPO=$(oc registry info --public)/ko-images
 ```
 
 # Acknowledgements


### PR DESCRIPTION
* Update the OpenShift documentation url to use latest instead of a specific version.
* Use `openshift registry info --public` to get registry public URL