### PR TITLE
[ci] upgrade to Go 1.17 everywhere, clean up configs

### DIFF
--- a/.github/workflows/boilerplate.yaml
+++ b/.github/workflows/boilerplate.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
 
       - run: |
           go build ./...

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.16.x
+        go-version: 1.17.x
 
     - name: Build and run ko container
       env:

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.16.x
+        go-version: 1.17.x
     - uses: actions/checkout@v2
 
     - name: Install ko

--- a/.github/workflows/modules-integration-test.yaml
+++ b/.github/workflows/modules-integration-test.yaml
@@ -5,18 +5,13 @@ on:
     branches: ['main']
 
 jobs:
-
   test:
     name: Module Tests
     strategy:
       matrix:
-        go-version: [1.16.x]
-        platform: [ubuntu-latest]
-
-    runs-on: ${{ matrix.platform }}
-
+        go-version: [1.16.x, 1.17.x]
+    runs-on: 'ubuntu-latest'
     steps:
-
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/modules-integration-test.yaml
+++ b/.github/workflows/modules-integration-test.yaml
@@ -12,16 +12,11 @@ jobs:
         go-version: [1.16.x, 1.17.x]
     runs-on: 'ubuntu-latest'
     steps:
-      - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v2
+      - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
-        id: go
+      - uses: actions/checkout@v2
 
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Test
-        env:
+      - env:
           GOPATH: does not matter
         run: ./integration_test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,20 +9,12 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v2
-      -
-        name: Unshallow
-        run: git fetch --prune --unshallow
-      -
-        name: Set up Go
-        uses: actions/setup-go@v1
+      - uses: actions/checkout@v2
+      - run: git fetch --prune --unshallow
+      - uses: actions/setup-go@v1
         with:
           go-version: 1.17.x
-      -
-        name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v1
+      - uses: goreleaser/goreleaser-action@v1
         with:
           version: latest
           args: release --rm-dist

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -23,10 +23,10 @@ jobs:
           importpath: golang.org/x/tools/cmd/goimports
 
     steps:
-      - name: Set up Go 1.16.x
+      - name: Set up Go 1.17.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
         id: go
 
       - name: Check out code
@@ -72,10 +72,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.16.x
+      - name: Set up Go 1.17.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
         id: go
 
       - name: Check out code

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -23,14 +23,10 @@ jobs:
           importpath: golang.org/x/tools/cmd/goimports
 
     steps:
-      - name: Set up Go 1.17.x
-        uses: actions/setup-go@v2
+      - uses: actions/setup-go@v2
         with:
           go-version: 1.17.x
-        id: go
-
-      - name: Check out code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
       - name: Install Dependencies
         if: ${{ matrix.importpath != '' }}
@@ -39,7 +35,6 @@ jobs:
           GO111MODULE=on go get ${{ matrix.importpath }}
 
       - name: ${{ matrix.tool }} ${{ matrix.options }}
-        shell: bash
         run: >
           ${{ matrix.tool }} ${{ matrix.options }} -w
           $(find .
@@ -50,7 +45,6 @@ jobs:
           -o -type f -name '*.go' -print)
 
       - name: Verify ${{ matrix.tool }}
-        shell: bash
         run: |
           # From: https://backreference.org/2009/12/23/how-to-match-newlines-in-sed/
           # This is to leverage this workaround:
@@ -72,14 +66,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.17.x
-        uses: actions/setup-go@v2
+      - uses: actions/setup-go@v2
         with:
           go-version: 1.17.x
-        id: go
-
-      - name: Check out code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
       - name: Install Tools
         env:
@@ -102,18 +92,11 @@ jobs:
 
           echo "${TEMP_PATH}" >> $GITHUB_PATH
 
-      - id: golangci_configuration
-        uses: andstor/file-existence-action@v1
-        with:
-          files: .golangci.yaml
-      - name: Go Lint
-        if: steps.golangci_configuration.outputs.files_exists == 'true'
-        uses: golangci/golangci-lint-action@v2
+      - uses: golangci/golangci-lint-action@v2
         with:
           version: v1.38
 
       - name: misspell
-        shell: bash
         if: ${{ always() }}
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
@@ -141,7 +124,6 @@ jobs:
           echo '::endgroup::'
 
       - name: trailing whitespace
-        shell: bash
         if: ${{ always() }}
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
@@ -170,7 +152,6 @@ jobs:
           echo '::endgroup::'
 
       - name: EOF newline
-        shell: bash
         if: ${{ always() }}
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
@@ -213,7 +194,6 @@ jobs:
       # since their action is not yet released under a stable version.
       - name: Language
         if: ${{ always() && github.event_name == 'pull_request' }}
-        shell: bash
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
 
       - run: go test -coverprofile=coverage.txt -covermode=atomic -race ./...
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.16.x
+        go-version: 1.17.x
     - uses: actions/checkout@v2
     - name: Verify
       run: ./hack/presubmit.sh

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package hack

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build tools
 // +build tools
 


### PR DESCRIPTION
- module integration test now runs with 1.16 and 1.17, and drops an unnecessary `matrix` value.
- drop unnecessary step `name`s (e.g., "Set up Go 1.17.x", which is redundant with the step config, and will only fall out of date and confuse people), and `shell:bash` (`bash` is the default value)