### PR TITLE
Always produce OCI images and indexes

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -923,7 +923,6 @@ func (g *gobuild) buildAll(ctx context.Context, ref string, baseIndex v1.ImageIn
 			Add: img,
 			Descriptor: v1.Descriptor{
 				URLs:        desc.URLs,
-				MediaType:   types.OCIManifestSchema1,
 				Annotations: desc.Annotations,
 				Platform:    desc.Platform,
 			},

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -700,6 +700,9 @@ func (g *gobuild) configForImportPath(ip string) Config {
 func (g *gobuild) buildOne(ctx context.Context, refStr string, base v1.Image, platform *v1.Platform) (v1.Image, error) {
 	ref := newRef(refStr)
 
+	// Always produce OCI images, even if the base image isn't an OCI image.
+	base = mutate.MediaType(base, types.OCIManifestSchema1)
+
 	cf, err := base.ConfigFile()
 	if err != nil {
 		return nil, err
@@ -876,16 +879,15 @@ func (g *gobuild) Build(ctx context.Context, s string) (Result, error) {
 	}
 
 	// Annotate the image or index with base image information.
-	// (Docker manifest lists don't support annotations)
-	if mt != types.DockerManifestList {
-		anns := map[string]string{
-			specsv1.AnnotationBaseImageDigest: baseDigest.String(),
-		}
-		if _, ok := baseRef.(name.Tag); ok {
-			anns[specsv1.AnnotationBaseImageName] = baseRef.Name()
-		}
-		res = mutate.Annotations(res, anns).(Result)
+	// If the result is an Index, it should be an OCI index that supports
+	// annotations.
+	anns := map[string]string{
+		specsv1.AnnotationBaseImageDigest: baseDigest.String(),
 	}
+	if _, ok := baseRef.(name.Tag); ok {
+		anns[specsv1.AnnotationBaseImageName] = baseRef.Name()
+	}
+	res = mutate.Annotations(res, anns).(Result)
 
 	return res, nil
 }
@@ -921,18 +923,14 @@ func (g *gobuild) buildAll(ctx context.Context, ref string, baseIndex v1.ImageIn
 			Add: img,
 			Descriptor: v1.Descriptor{
 				URLs:        desc.URLs,
-				MediaType:   desc.MediaType,
+				MediaType:   types.OCIManifestSchema1,
 				Annotations: desc.Annotations,
 				Platform:    desc.Platform,
 			},
 		})
 	}
 
-	baseType, err := baseIndex.MediaType()
-	if err != nil {
-		return nil, err
-	}
-	idx := mutate.IndexMediaType(mutate.AppendManifests(empty.Index, adds...), baseType)
+	idx := mutate.IndexMediaType(mutate.AppendManifests(empty.Index, adds...), types.OCIImageIndex)
 
 	return idx, nil
 }

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	specsv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -418,6 +419,17 @@ func TestGoBuildNoKoData(t *testing.T) {
 			t.Errorf("created = %v, want %v", actual, creationTime)
 		}
 	})
+
+	t.Run("check OCI media type", func(t *testing.T) {
+		mt, err := img.MediaType()
+		if err != nil {
+			t.Errorf("MediaType() = %v", err)
+		}
+
+		if got, want := mt, types.OCIManifestSchema1; got != want {
+			t.Errorf("mediaType = %v, want %v", got, want)
+		}
+	})
 }
 
 func validateImage(t *testing.T, img v1.Image, baseLayers int64, creationTime v1.Time, checkAnnotations bool) {
@@ -727,6 +739,17 @@ func TestGoBuildIndex(t *testing.T) {
 
 		if d1 != d2 {
 			t.Errorf("Digest mismatch: %s != %s", d1, d2)
+		}
+	})
+
+	t.Run("check OCI media type", func(t *testing.T) {
+		mt, err := idx.MediaType()
+		if err != nil {
+			t.Errorf("MediaType() = %v", err)
+		}
+
+		if got, want := mt, types.OCIImageIndex; got != want {
+			t.Errorf("mediaType = %v, want %v", got, want)
 		}
 	})
 }

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -745,11 +745,17 @@ func TestGoBuildIndex(t *testing.T) {
 	t.Run("check OCI media type", func(t *testing.T) {
 		mt, err := idx.MediaType()
 		if err != nil {
-			t.Errorf("MediaType() = %v", err)
+			t.Fatalf("MediaType() = %v", err)
 		}
 
 		if got, want := mt, types.OCIImageIndex; got != want {
 			t.Errorf("mediaType = %v, want %v", got, want)
+		}
+
+		for i, mf := range im.Manifests {
+			if got, want := mf.MediaType, types.OCIManifestSchema1; got != want {
+				t.Errorf("manifest[%d] mediaType = %s, want %s", i, got, want)
+			}
 		}
 	})
 }


### PR DESCRIPTION
Followup from #354 

Before this change, if the base image was a Docker manifest list, it could not be annotated with base image information. With this change, `ko` always produces OCI images and indexes, which can be annotated.

Verified manually as well:

```
$ crane manifest $(go run ./ publish ./test --platform=all) | jq '.annotations'
...
{
  "org.opencontainers.image.base.digest": "sha256:7cb5539ebb7b99352d736ed97668060cee123285f01705b910891acdf7d945e3",
  "org.opencontainers.image.base.name": "gcr.io/distroless/static:nonroot"
}                                                                                                                                                      
```