### PR TITLE
Validate KO_CONFIG_PATH 

### DIFF
--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -108,10 +108,6 @@ func (bo *BuildOptions) LoadConfig() error {
 		}
 		v.AddConfigPath(override)
 	}
-
-	if bo.WorkingDirectory == "" {
-		bo.WorkingDirectory = "."
-	}
 	v.AddConfigPath(bo.WorkingDirectory)
 
 	if err := v.ReadInConfig(); err != nil {

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -91,14 +91,27 @@ func (bo *BuildOptions) LoadConfig() error {
 	}
 	// If omitted, use this base image.
 	v.SetDefault("defaultBaseImage", configDefaultBaseImage)
-	v.SetConfigName(".ko") // .yaml is implicit
+	const configName = ".ko"
+
+	v.SetConfigName(configName) // .yaml is implicit
 	v.SetEnvPrefix("KO")
 	v.AutomaticEnv()
 
 	if override := os.Getenv("KO_CONFIG_PATH"); override != "" {
+		path := filepath.Join(override, configName+".yaml")
+		file, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("error looking for config file: %w", err)
+		}
+		if !file.Mode().IsRegular() {
+			return fmt.Errorf("config file %s is not a regular file", path)
+		}
 		v.AddConfigPath(override)
 	}
 
+	if bo.WorkingDirectory == "" {
+		bo.WorkingDirectory = "."
+	}
 	v.AddConfigPath(bo.WorkingDirectory)
 
 	if err := v.ReadInConfig(); err != nil {

--- a/pkg/commands/options/build_test.go
+++ b/pkg/commands/options/build_test.go
@@ -15,6 +15,8 @@
 package options
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/ko/pkg/build"
@@ -95,5 +97,43 @@ func TestAddBuildOptionsSetsDefaultsForNonFlagOptions(t *testing.T) {
 	AddBuildOptions(cmd, bo)
 	if !bo.Trimpath {
 		t.Error("expected Trimpath=true")
+	}
+}
+
+func TestOverrideConfigPath(t *testing.T) {
+	const envName = "KO_CONFIG_PATH"
+	bo := &BuildOptions{}
+	for _, tc := range []struct {
+		name         string
+		koConfigPath string
+		err          string
+	}{{
+		name:         ".ko.yaml does not exist",
+		koConfigPath: "testdata",
+		err:          "testdata/.ko.yaml: no such file or directory",
+	}, {
+		name:         ".ko.yaml is dir",
+		koConfigPath: "testdata/bad-config",
+		err:          "testdata/bad-config/.ko.yaml is not a regular file",
+	}, {
+		name:         "good",
+		koConfigPath: "testdata/config",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			oldEnv := os.Getenv(envName)
+			defer os.Setenv(envName, oldEnv)
+
+			os.Setenv(envName, tc.koConfigPath)
+			err := bo.LoadConfig()
+			if err == nil {
+				if tc.err == "" {
+					return
+				}
+				t.Fatalf("expected error %q, saw nil", tc.err)
+			}
+			if !strings.Contains(err.Error(), tc.err) {
+				t.Errorf("expected error to contain %q, saw: %v", tc.err, err)
+			}
+		})
 	}
 }

--- a/pkg/commands/options/testdata/bad-config/.ko.yaml/.gitignore
+++ b/pkg/commands/options/testdata/bad-config/.ko.yaml/.gitignore
@@ -1,0 +1,3 @@
+.# We just want to have a practically empty directory.
+*
+!.gitignore


### PR DESCRIPTION
This avoids surprises when:
- users include `.ko.yaml` in their KO_CONFIG_PATH (i.e. pointing to a file)
- users specify a wrong directory