### PR TITLE
Fix handling of 'has' selectors

### DIFF
--- a/pkg/resolve/selector.go
+++ b/pkg/resolve/selector.go
@@ -38,6 +38,9 @@ func MatchesSelector(doc *yaml.Node, selector labels.Selector) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if kind == "" {
+		return false, nil
+	}
 
 	if kind == "List" {
 		return listMatchesSelector(doc, selector)
@@ -96,11 +99,12 @@ func objMatchesSelector(doc *yaml.Node, selector labels.Selector) bool {
 
 	node, ok := it()
 
-	if ok && selector.Matches(labelsNode{node}) {
-		return true
+	// Object has no metadata.labels, verify matching against an empty set.
+	if !ok {
+		node = emptyMapNode
 	}
 
-	return false
+	return selector.Matches(labelsNode{node})
 }
 
 func listMatchesSelector(doc *yaml.Node, selector labels.Selector) (bool, error) {
@@ -132,6 +136,11 @@ func listMatchesSelector(doc *yaml.Node, selector labels.Selector) (bool, error)
 
 	node.Content = matches
 	return len(matches) != 0, nil
+}
+
+var emptyMapNode = &yaml.Node{
+	Kind: yaml.MappingNode,
+	Tag:  "!!map",
 }
 
 type labelsNode struct {

--- a/pkg/resolve/selector_test.go
+++ b/pkg/resolve/selector_test.go
@@ -195,11 +195,6 @@ func TestMatchesSelector(t *testing.T) {
 		input:    podList,
 		selector: labels.Nothing(),
 		matches:  false,
-	}, {
-		desc:     "null node",
-		input:    "!!null",
-		selector: labels.Everything(),
-		matches:  false,
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #467

The first commit includes test cases which surface the issue.

The second one includes a fix, which consists in treating a missing `metadata.labels` as a `{}` map.

---

Test run before fix:

```
--- FAIL: TestMatchesSelector (0.00s)

    --- FAIL: TestMatchesSelector/single_non-labeled_object_with_not-has_selector (0.00s)
        selector_test.go:215: unexpected result: got false - want true

    --- FAIL: TestMatchesSelector/not-has_selector_matching_all_non-labeled_elements_of_list_object (0.00s)
        selector_test.go:200: unexpected result: got false - want true
        selector_test.go:209: unexpected diff (-want, +got)   (
                """
                ... // 3 identical lines
                    resourceVersion: ""
                    selfLink: ""
            -   items:
            -       - apiVersion: v1
            -         kind: Pod
            -         metadata:
            -           name: rss-site
            -       - apiVersion: v1
            -         kind: Pod
            -         metadata:
            -           name: rss-db
            +   items: []
                """
              )
```