### PR TITLE
use github api to generate the changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,6 +38,7 @@ snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
+  use: github
   filters:
     exclude:
     - '^docs:'


### PR DESCRIPTION
This gives the credits to contributors in the changelog by appending their usernames to the commits. [See an example.](https://github.com/goreleaser/goreleaser/releases/tag/v0.181.1)

Its a new goreleaser feature and I particularly think is kind of cool that github now shows the avatars of contributors et al, so here it in case you folks find it interesting as well.

Signed-off-by: Carlos A Becker <caarlos0@gmail.com>

