### PR TITLE
Allow to customize `publish.Namer`

### DIFF
--- a/pkg/commands/options/namer_test.go
+++ b/pkg/commands/options/namer_test.go
@@ -1,18 +1,16 @@
-/*
-Copyright 2021 Google LLC All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2021 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package options_test
 
@@ -24,16 +22,21 @@ import (
 )
 
 func TestMakeNamer(t *testing.T) {
-	for _, namerCase := range testMakeNamerCases() {
-		namerCase := namerCase
-		t.Run(namerCase.name, func(t *testing.T) {
-			namer := options.MakeNamer(&namerCase.opts)
+	foreachTestCaseMakeNamer(func(tc testMakeNamerCase) {
+		t.Run(tc.name, func(t *testing.T) {
+			namer := options.MakeNamer(&tc.opts)
 			got := namer("registry.example.org/foo/bar", "example.org/sample/cmd/example")
 
-			if got != namerCase.want {
-				t.Errorf("got image name %s, wanted %s", got, namerCase.want)
+			if got != tc.want {
+				t.Errorf("got image name %s, wanted %s", got, tc.want)
 			}
 		})
+	})
+}
+
+func foreachTestCaseMakeNamer(fn func(tc testMakeNamerCase)) {
+	for _, namerCase := range testMakeNamerCases() {
+		fn(namerCase)
 	}
 }
 
@@ -41,10 +44,6 @@ func testMakeNamerCases() []testMakeNamerCase {
 	return []testMakeNamerCase{{
 		name: "defaults",
 		want: "registry.example.org/foo/bar/example-51d74b7127c5f7495a338df33ecdeb19",
-	}, {
-		name: "with different separator",
-		want: "registry.example.org/foo/bar-example-51d74b7127c5f7495a338df33ecdeb19",
-		opts: options.PublishOptions{ImageNameSeparator: "-"},
 	}, {
 		name: "with preserve import paths",
 		want: "registry.example.org/foo/bar/example.org/sample/cmd/example",
@@ -54,18 +53,14 @@ func testMakeNamerCases() []testMakeNamerCase {
 		want: "registry.example.org/foo/bar/example",
 		opts: options.PublishOptions{BaseImportPaths: true},
 	}, {
-		name: "with base import paths and custom separator",
-		want: "registry.example.org/foo/bar-example",
-		opts: options.PublishOptions{BaseImportPaths: true, ImageNameSeparator: "-"},
-	}, {
 		name: "with bare",
 		want: "registry.example.org/foo/bar",
 		opts: options.PublishOptions{Bare: true},
 	}, {
 		name: "with custom namer",
-		want: "registry.example.org/foo/bar!example",
+		want: "registry.example.org/foo/bar-example",
 		opts: options.PublishOptions{ImageNamer: func(base string, importpath string) string {
-			return base + "!" + path.Base(importpath)
+			return base + "-" + path.Base(importpath)
 		}},
 	}}
 }


### PR DESCRIPTION
Fixes #476

- Adds ability to pass custom `publish.Namer`
- Adds ability to override default path separator, allowing use with container registries that don't allow nested repositories (Quay, Docker Hub etc.)