### PR TITLE
Add e2e test for using ldflags to set a build-time variable

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -49,3 +49,14 @@ jobs:
         if [[ "$RUNNER_OS" == "Linux" ]]; then
           docker run ${testimg} --wait=false -f HEAD
         fi
+
+        # Check that using ldflags to set variables works.
+        cat > .ko.yaml << EOF
+        builds:
+        - id: test
+          main: ./test/
+          ldflags:
+          - "-X main.version=${{ github.sha }}"
+        EOF
+        docker run $(go run ./ publish ./test/ --platform=${GOOS}/${GOARCH}) --wait=false 2>&1 | grep "${{ github.sha }}"
+

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,0 @@
-defaultBaseImage: gcr.io/distroless/static:nonroot

--- a/test/main.go
+++ b/test/main.go
@@ -29,8 +29,13 @@ var (
 	wait = flag.Bool("wait", true, "Whether to wait for SIGTERM")
 )
 
+// This is defined so we can test build-time variable setting using ldflags.
+var version = "default"
+
 func main() {
 	flag.Parse()
+
+	log.Println("version =", version)
 
 	dp := os.Getenv("KO_DATA_PATH")
 	file := filepath.Join(dp, *f)


### PR DESCRIPTION
This tests and demonstrates using ldflags in a `.ko.yaml` file to set a variable value at build-time.