### PR TITLE
Fix issue where kubectl apply is run in place of kubectl create

### DIFF
--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -86,7 +86,7 @@ func addCreate(topLevel *cobra.Command) {
 			// Issue a "kubectl create" command reading from stdin,
 			// to which we will pipe the resolved files, and any
 			// remaining flags passed after '--'.
-			argv := []string{"apply", "-f", "-"}
+			argv := []string{"create", "-f", "-"}
 			if kflags := kf.Values(); len(kflags) != 0 {
 				skflags := strings.Join(stripPassword(kflags), " ")
 				log.Printf(kubectlFlagsWarningTemplate,


### PR DESCRIPTION
I think this use of `kubectl create` was accidentally replaced by `kubectl apply` (assumption based on the fact that the comments and error messages surrounding this change weren't updated to reflect new use of `apply`).

We've started seeing errors from `ko` in Tekton Pipelines' integration test runs with the following format today, which I believe are related:

```
        error: from default-cluster-admin-: cannot use generate name with apply
        Error: error executing 'kubectl create': exit status 1
        2021/11/09 16:40:53 error during command execution:error executing 'kubectl create': exit status 1
```