### PR TITLE
Add `Trimpath` build option

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -65,6 +65,7 @@ type gobuild struct {
 	kodataCreationTime   v1.Time
 	build                builder
 	disableOptimizations bool
+	trimpath             bool
 	buildConfigs         map[string]Config
 	platformMatcher      *platformMatcher
 	dir                  string
@@ -80,6 +81,7 @@ type gobuildOpener struct {
 	kodataCreationTime   v1.Time
 	build                builder
 	disableOptimizations bool
+	trimpath             bool
 	buildConfigs         map[string]Config
 	platform             string
 	labels               map[string]string
@@ -100,6 +102,7 @@ func (gbo *gobuildOpener) Open() (Interface, error) {
 		kodataCreationTime:   gbo.kodataCreationTime,
 		build:                gbo.build,
 		disableOptimizations: gbo.disableOptimizations,
+		trimpath:             gbo.trimpath,
 		buildConfigs:         gbo.buildConfigs,
 		labels:               gbo.labels,
 		dir:                  gbo.dir,
@@ -556,9 +559,10 @@ func createBuildArgs(buildCfg Config) ([]string, error) {
 }
 
 func (g *gobuild) configForImportPath(ip string) Config {
-	config, ok := g.buildConfigs[ip]
-	if !ok {
-		// Apply default build flags in case none were supplied
+	config := g.buildConfigs[ip]
+	if g.trimpath {
+		// The `-trimpath` flag removes file system paths from the resulting binary, to aid reproducibility.
+		// Ref: https://pkg.go.dev/cmd/go#hdr-Compile_packages_and_dependencies
 		config.Flags = append(config.Flags, "-trimpath")
 	}
 

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -54,6 +54,15 @@ func WithDisabledOptimizations() Option {
 	}
 }
 
+// WithTrimpath is a functional option that controls whether the `-trimpath`
+// flag is added to `go build`.
+func WithTrimpath(v bool) Option {
+	return func(gbo *gobuildOpener) error {
+		gbo.trimpath = v
+		return nil
+	}
+}
+
 // WithConfig is a functional option for providing GoReleaser Build influenced
 // build settings for importpaths.
 //

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -58,6 +58,12 @@ type BuildOptions struct {
 
 	InsecureRegistry bool
 
+	// Trimpath controls whether ko adds the `-trimpath` flag to `go build` by default.
+	// The `-trimpath` flags aids in achieving reproducible builds, but it removes path information that is useful for interactive debugging.
+	// Set this field to `false` and `DisableOptimizations` to `true` if you want to interactively debug the binary in the resulting image.
+	// `AddBuildOptions()` defaults this field to `true`.
+	Trimpath bool
+
 	// BuildConfigs stores the per-image build config from `.ko.yaml`.
 	BuildConfigs map[string]build.Config
 }
@@ -71,6 +77,7 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*")
 	cmd.Flags().StringSliceVar(&bo.Labels, "image-label", []string{},
 		"Which labels (key=value) to add to the image.")
+	bo.Trimpath = true
 }
 
 // LoadConfig reads build configuration from defaults, environment variables, and the `.ko.yaml` config file.

--- a/pkg/commands/options/build_test.go
+++ b/pkg/commands/options/build_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/google/ko/pkg/build"
+	"github.com/spf13/cobra"
 )
 
 func TestDefaultBaseImage(t *testing.T) {
@@ -85,5 +86,14 @@ func TestCreateBuildConfigs(t *testing.T) {
 				t.Fatalf("unknown test case: %s", buildCfg.ID)
 			}
 		}
+	}
+}
+
+func TestAddBuildOptionsSetsDefaultsForNonFlagOptions(t *testing.T) {
+	cmd := &cobra.Command{}
+	bo := &BuildOptions{}
+	AddBuildOptions(cmd, bo)
+	if !bo.Trimpath {
+		t.Error("expected Trimpath=true")
 	}
 }

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -99,6 +99,7 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 	if bo.DisableOptimizations {
 		opts = append(opts, build.WithDisabledOptimizations())
 	}
+	opts = append(opts, build.WithTrimpath(bo.Trimpath))
 	for _, lf := range bo.Labels {
 		parts := strings.SplitN(lf, "=", 2)
 		if len(parts) != 2 {


### PR DESCRIPTION
Enables programmatic control of adding the `-trimpath` flag to `go build`.

The `-trimpath` flag removes file system paths from the resulting binary. `ko` adds `-trimpath` by default as it aids in achieving reproducible builds.

However, removing file system paths makes interactive debugging more challenging, in particular in mapping source file locations in the IDE to debug information in the binary.

If you set `Trimpath` to `false` to enable interactive debugging, you likely also want to set `DisableOptimizations` to `true` to disable compiler optimizations and inlining.

Reference for `-trimpath`: https://pkg.go.dev/cmd/go#hdr-Compile_packages_and_dependencies

Resolves: #500
Related: #71, #78, https://github.com/GoogleContainerTools/skaffold/issues/6843