### PR TITLE
Connect SBOMs with SPDX support.

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -86,7 +86,7 @@ jobs:
 
         IMAGE=$(ko build ./test)
         SBOM=$(cosign download sbom ${IMAGE})
-        KO_DEPS=$(ko deps --sbom=spdx ${IMAGE})
+        KO_DEPS=$(ko deps ${IMAGE})
 
         echo '::group:: SBOM'
         echo "${SBOM}"

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -84,9 +84,9 @@ jobs:
       run: |
         set -o pipefail
 
-        IMAGE=$(ko publish ./test)
+        IMAGE=$(ko build ./test)
         SBOM=$(cosign download sbom ${IMAGE})
-        KO_DEPS=$(ko deps ${IMAGE})
+        KO_DEPS=$(ko deps --sbom=spdx ${IMAGE})
 
         echo '::group:: SBOM'
         echo "${SBOM}"

--- a/doc/ko_apply.md
+++ b/doc/ko_apply.md
@@ -72,7 +72,7 @@ ko apply -f FILENAME [flags]
       --push                           Push images to KO_DOCKER_REPO (default true)
   -R, --recursive                      Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (DEPRECATED)
-      --sbom string                    The SBOM media type to use (none will disable SBOM synthesis and upload). (default "go.version-m")
+      --sbom string                    The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m). (default "spdx")
   -l, --selector string                Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
   -s, --server string                  The address and port of the Kubernetes API server (DEPRECATED)
       --tag-only                       Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.

--- a/doc/ko_build.md
+++ b/doc/ko_build.md
@@ -55,7 +55,7 @@ ko build IMPORTPATH... [flags]
       --platform string          Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
       --push                     Push images to KO_DOCKER_REPO (default true)
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload). (default "go.version-m")
+      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m). (default "spdx")
       --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
       --tarball string           File to save images tarballs

--- a/doc/ko_create.md
+++ b/doc/ko_create.md
@@ -72,7 +72,7 @@ ko create -f FILENAME [flags]
       --push                           Push images to KO_DOCKER_REPO (default true)
   -R, --recursive                      Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (DEPRECATED)
-      --sbom string                    The SBOM media type to use (none will disable SBOM synthesis and upload). (default "go.version-m")
+      --sbom string                    The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m). (default "spdx")
   -l, --selector string                Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
   -s, --server string                  The address and port of the Kubernetes API server (DEPRECATED)
       --tag-only                       Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.

--- a/doc/ko_deps.md
+++ b/doc/ko_deps.md
@@ -24,7 +24,7 @@ ko deps IMAGE [flags]
 
 ```
   -h, --help          help for deps
-      --sbom string   Format for SBOM output (default "go.version-m")
+      --sbom string   Format for SBOM output (supports: spdx, go.version-m). (default "spdx")
 ```
 
 ### SEE ALSO

--- a/doc/ko_resolve.md
+++ b/doc/ko_resolve.md
@@ -52,7 +52,7 @@ ko resolve -f FILENAME [flags]
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
       --push                     Push images to KO_DOCKER_REPO (default true)
   -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload). (default "go.version-m")
+      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m). (default "spdx")
   -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
       --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])

--- a/doc/ko_run.md
+++ b/doc/ko_run.md
@@ -42,7 +42,7 @@ ko run IMPORTPATH [flags]
       --platform string          Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
       --push                     Push images to KO_DOCKER_REPO (default true)
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload). (default "go.version-m")
+      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m). (default "spdx")
       --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
       --tarball string           File to save images tarballs

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -392,7 +392,7 @@ func nilGetBase(_ context.Context, _ string) (name.Reference, Result, error) {
 const wantSBOM = "This is our fake SBOM"
 
 // A helper method we use to substitute for the default "build" method.
-func fauxSBOM(_ context.Context, _ string, _ string) ([]byte, types.MediaType, error) {
+func fauxSBOM(_ context.Context, _ string, _ string, _ v1.Image) ([]byte, types.MediaType, error) {
 	return []byte(wantSBOM), "application/vnd.garbage", nil
 }
 

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -57,7 +57,7 @@ func WithDisabledOptimizations() Option {
 // WithDisabledSBOM is a functional option for disabling SBOM generation.
 func WithDisabledSBOM() Option {
 	return func(gbo *gobuildOpener) error {
-		gbo.disableSBOM = true
+		gbo.sbom = nil
 		return nil
 	}
 }
@@ -112,6 +112,24 @@ func WithLabel(k, v string) Option {
 func withBuilder(b builder) Option {
 	return func(gbo *gobuildOpener) error {
 		gbo.build = b
+		return nil
+	}
+}
+
+// WithGoVersionSBOM is a functional option to direct ko to use
+// go version -m for SBOM format.
+func WithGoVersionSBOM() Option {
+	return func(gbo *gobuildOpener) error {
+		gbo.sbom = goversionm
+		return nil
+	}
+}
+
+// WithSPDX is a functional option to direct ko to use
+// SPDX for SBOM format.
+func WithSPDX(version string) Option {
+	return func(gbo *gobuildOpener) error {
+		gbo.sbom = spdx(version)
 		return nil
 	}
 }

--- a/pkg/commands/deps.go
+++ b/pkg/commands/deps.go
@@ -148,6 +148,6 @@ If the image was not built using ko, or if it was built without embedding depend
 			// unreachable
 		},
 	}
-	deps.Flags().StringVar(&sbomType, "sbom", "go.version-m", "Format for SBOM output")
+	deps.Flags().StringVar(&sbomType, "sbom", "spdx", "Format for SBOM output (supports: spdx, go.version-m).")
 	topLevel.AddCommand(deps)
 }

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -74,8 +74,8 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"The maximum number of concurrent builds (default GOMAXPROCS)")
 	cmd.Flags().BoolVar(&bo.DisableOptimizations, "disable-optimizations", bo.DisableOptimizations,
 		"Disable optimizations when building Go code. Useful when you want to interactively debug the created container.")
-	cmd.Flags().StringVar(&bo.SBOM, "sbom", "go.version-m",
-		"The SBOM media type to use (none will disable SBOM synthesis and upload).")
+	cmd.Flags().StringVar(&bo.SBOM, "sbom", "spdx",
+		"The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m).")
 	cmd.Flags().StringVar(&bo.Platform, "platform", "",
 		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*")
 	cmd.Flags().StringSliceVar(&bo.Labels, "image-label", []string{},

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -102,6 +102,10 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 	switch bo.SBOM {
 	case "none":
 		opts = append(opts, build.WithDisabledSBOM())
+	case "spdx":
+		opts = append(opts, build.WithSPDX(version()))
+	case "go.version-m":
+		opts = append(opts, build.WithGoVersionSBOM())
 	}
 	opts = append(opts, build.WithTrimpath(bo.Trimpath))
 	for _, lf := range bo.Labels {


### PR DESCRIPTION
This combines Jason's SPDX stuff and my SBOM stuff to support
SPDX-based SBOMs by default instead of our `go version -m`
invention.

To simplify things, I got rid of `disableSBOM` in favor of supporting
`nil` and simply eliding the SBOM call.