### PR TITLE
Normalize the package hash to hex.

### DIFF
--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -102,10 +102,10 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 	switch bo.SBOM {
 	case "none":
 		opts = append(opts, build.WithDisabledSBOM())
-	case "spdx":
-		opts = append(opts, build.WithSPDX(version()))
 	case "go.version-m":
 		opts = append(opts, build.WithGoVersionSBOM())
+	default: // "spdx"
+		opts = append(opts, build.WithSPDX(version()))
 	}
 	opts = append(opts, build.WithTrimpath(bo.Trimpath))
 	for _, lf := range bo.Labels {


### PR DESCRIPTION
We were emitting package checksum hashes as `h1:{base64}`.  `h1:` is a prefix that indicates "Hash 1", which is a SHA-256 based hash of the files, which is then base64 encoded as the suffix.

This change detects/strips the `h1:` prefix and re-encodes the base64 data as hex.

I also combined the two loops over `.Deps` since I noticed `bom` doing things in this order. 🤷 