### PR TITLE
Support Openshift's internal registry with ocp.local.

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,8 +513,8 @@ Oh, you betcha. Here's a partial list:
 
 ## Does `ko` work with [OpenShift Internal Registry](https://docs.openshift.com/container-platform/latest/registry/registry-options.html#registry-integrated-openshift-registry_registry-options)?
 
-We've got you covered! Make sure you're
-[logged into `oc`](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands)
+We've got you covered! Make sure 
+[you've installed `oc` and you're logged into your cluster](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands)
 with a user that's allowed to push to the internal registry and use `ocp.local` as your
 `KO_DOCKER_REPO`. The images will be published into the currently active project.
 

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ Oh, you betcha. Here's a partial list:
 
 ## Does `ko` work with [OpenShift Internal Registry](https://docs.openshift.com/container-platform/latest/registry/registry-options.html#registry-integrated-openshift-registry_registry-options)?
 
-We've got you covered! Make sure 
+We've got you covered! Make sure
 [you've installed `oc` and you're logged into your cluster](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands)
 with a user that's allowed to push to the internal registry and use `ocp.local` as your
 `KO_DOCKER_REPO`. The images will be published into the currently active project.

--- a/README.md
+++ b/README.md
@@ -513,25 +513,10 @@ Oh, you betcha. Here's a partial list:
 
 ## Does `ko` work with [OpenShift Internal Registry](https://docs.openshift.com/container-platform/latest/registry/registry-options.html#registry-integrated-openshift-registry_registry-options)?
 
-Yes! Follow these steps:
-
-- Connect to your OpenShift installation:
-  https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands
-- Expose the OpenShift Internal Registry so you can push to it:
-  https://docs.openshift.com/container-platform/latest/registry/securing-exposing-registry.html
-- Export your token to `$HOME/.docker/config.json`:
-
-```sh
-oc registry login --to=$HOME/.docker/config.json
-```
-
-- Create a namespace where you will push your images, i.e: `ko-images`
-- Execute this command to set `KO_DOCKER_REPO` to publish images to the internal
-  registry.
-
-```sh
-   export KO_DOCKER_REPO=$(oc registry info --public)/ko-images
-```
+We've got you covered! Make sure you're
+[logged into `oc`](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands)
+with a user that's allowed to push to the internal registry and use `ocp.local` as your
+`KO_DOCKER_REPO`. The images will be published into the currently active project.
 
 # Acknowledgements
 

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -188,8 +188,8 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 		if repoName == publish.KindDomain {
 			return publish.NewKindPublisher(namer, po.Tags), nil
 		}
-		if repoName == publish.OpenshiftDomain {
-			return publish.NewOpenshiftPublisher(namer, po.Tags)
+		if repoName == publish.OpenShiftDomain {
+			return publish.NewOpenShiftPublisher(namer, po.Tags)
 		}
 
 		if repoName == "" {

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -188,6 +188,9 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 		if repoName == publish.KindDomain {
 			return publish.NewKindPublisher(namer, po.Tags), nil
 		}
+		if repoName == publish.OpenshiftDomain {
+			return publish.NewOpenshiftPublisher(namer, po.Tags)
+		}
 
 		if repoName == "" {
 			return nil, errors.New("KO_DOCKER_REPO environment variable is unset")

--- a/pkg/publish/openshift.go
+++ b/pkg/publish/openshift.go
@@ -32,9 +32,9 @@ import (
 )
 
 const (
-	// OpenshiftDomain is a sentinel "registry" that represents loading images into
-	// Openshift's internal registry.
-	OpenshiftDomain = "ocp.local"
+	// OpenShiftDomain is a sentinel "registry" that represents loading images into
+	// OpenShift's internal registry.
+	OpenShiftDomain = "ocp.local"
 
 	// This line is printed by the tunnel command when it tells us which port it uses.
 	portPrefix = "Forwarding from 127.0.0.1:"
@@ -45,9 +45,9 @@ type ocpPublisher struct {
 	tunnel *os.Process
 }
 
-// NewOpenshiftPublisher returns a new publish.Interface that loads images into
-// Openshift's internal registry.
-func NewOpenshiftPublisher(namer Namer, tags []string) (Interface, error) {
+// NewOpenShiftPublisher returns a new publish.Interface that loads images into
+// OpenShift's internal registry.
+func NewOpenShiftPublisher(namer Namer, tags []string) (Interface, error) {
 	// Login to the registry.
 	if _, err := runOc("registry", "login"); err != nil {
 		return nil, fmt.Errorf("failed to login to the registry: %w", err)

--- a/pkg/publish/openshift.go
+++ b/pkg/publish/openshift.go
@@ -66,6 +66,7 @@ func NewOpenShiftPublisher(namer Namer, tags []string) (Interface, error) {
 	// Note: port-forward is a privileged operation on Openshift, so we build an pipe
 	//       tunnel using a socat pod and attaching to its pipes.
 	// TODO: Should we generalize this into a ko feature for a tunneled registry?
+	//nolint:gosec // Launching this command with the output of the registry call above.
 	tunnel := exec.Command("oc", "run", "registry-tunnel", "--rm", "-i", "--image", "alpine/socat", "--", "-", "TCP4:"+registryHostPort)
 	in, err := tunnel.StdinPipe()
 	if err != nil {

--- a/pkg/publish/openshift.go
+++ b/pkg/publish/openshift.go
@@ -48,6 +48,11 @@ type ocpPublisher struct {
 // NewOpenShiftPublisher returns a new publish.Interface that loads images into
 // OpenShift's internal registry.
 func NewOpenShiftPublisher(namer Namer, tags []string) (Interface, error) {
+	// Check if oc is installed.
+	if _, err := exec.LookPath("oc"); err != nil {
+		return nil, fmt.Errorf("failed to find oc, is it installed? : %w", err)
+	}
+
 	// Login to the registry.
 	if _, err := runOc("registry", "login"); err != nil {
 		return nil, fmt.Errorf("failed to login to the registry: %w", err)

--- a/pkg/publish/openshift.go
+++ b/pkg/publish/openshift.go
@@ -49,8 +49,7 @@ type ocpPublisher struct {
 // Openshift's internal registry.
 func NewOpenshiftPublisher(namer Namer, tags []string) (Interface, error) {
 	// Login to the registry.
-	login := exec.Command("oc", "registry", "login")
-	if err := login.Run(); err != nil {
+	if _, err := runOc("registry", "login"); err != nil {
 		return nil, fmt.Errorf("failed to login to the registry: %w", err)
 	}
 	log.Print("Logged into Openshift registry")

--- a/pkg/publish/openshift.go
+++ b/pkg/publish/openshift.go
@@ -1,0 +1,154 @@
+// Copyright 2021 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publish
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/ko/pkg/build"
+)
+
+const (
+	// OpenshiftDomain is a sentinel "registry" that represents loading images into
+	// Openshift's internal registry.
+	OpenshiftDomain = "ocp.local"
+
+	// This line is printed by the tunnel command when it tells us which port it uses.
+	portPrefix = "Forwarding from 127.0.0.1:"
+)
+
+type ocpPublisher struct {
+	inner  Interface
+	tunnel *os.Process
+}
+
+// NewOpenshiftPublisher returns a new publish.Interface that loads images into
+// Openshift's internal registry.
+func NewOpenshiftPublisher(namer Namer, tags []string) (Interface, error) {
+	// Login to the registry.
+	login := exec.Command("oc", "registry", "login")
+	if err := login.Run(); err != nil {
+		return nil, fmt.Errorf("failed to login to the registry: %w", err)
+	}
+	log.Print("Logged into Openshift registry")
+
+	registryHostPort, err := runOc("registry", "info", "--internal")
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch internal registry host: %w", err)
+	}
+	registryHost, registryPort, err := net.SplitHostPort(registryHostPort)
+	if err != nil {
+		return nil, fmt.Errorf("failed to split host and port of registry: %w", err)
+	}
+	registryHostParts := strings.SplitN(registryHost, ".", 3)
+	registrySvc := registryHostParts[0]
+	registryNs := registryHostParts[1]
+
+	// Setup a tunnel to the registry.
+	// TODO: Should we generalize this into a ko feature for a tunneled registry?
+	tunnel := exec.Command("oc", "port-forward", "-n", registryNs, "svc/"+registrySvc, ":"+registryPort)
+	tunnel.Stderr = os.Stderr
+	tunnelLogs, err := tunnel.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tunnel output: %w", err)
+	}
+	if err := tunnel.Start(); err != nil {
+		return nil, fmt.Errorf("failed to launch tunnel: %w", err)
+	}
+
+	// Wait for the "Forwarding from" logline to appear.
+	var tunnelPort string
+	scanner := bufio.NewScanner(tunnelLogs)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, portPrefix) {
+			tunnelPort = strings.TrimPrefix(strings.TrimSuffix(line, " -> 5000"), portPrefix)
+			break
+		}
+	}
+	// Drop all remaining stdout logs into a black hole so that the process can continue.
+	go io.Copy(io.Discard, tunnelLogs)
+	log.Printf("Using local tunnel with port %q", tunnelPort)
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	dial := transport.DialContext
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		// Force connect to the local tunnel.
+		// TODO: Should we generalize this into the default handler so people can use
+		//       existing tunnels in the default publisher?
+		return dial(ctx, "tcp", "127.0.0.1:"+tunnelPort)
+	}
+
+	// Determine the namespace to push the image to by assuming the user wants to push to
+	// the active project.
+	// Note: This is fine for single-namespace deployments but will fail if the manifest
+	//       contains deployments in different namespaces.
+	targetNamespace, err := runOc("project", "-q")
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine active project: %w", err)
+	}
+	log.Printf("Pushing images to namespace %q", targetNamespace)
+
+	inner, err := NewDefault(fmt.Sprintf("%s.%s.svc:%s/%s", registrySvc, registryNs, registryPort, targetNamespace),
+		WithTransport(transport),
+		WithAuthFromKeychain(authn.DefaultKeychain),
+		WithNamer(namer),
+		WithTags(tags),
+		Insecure(true))
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize inner publisher: %w", err)
+	}
+
+	return &ocpPublisher{
+		inner:  inner,
+		tunnel: tunnel.Process,
+	}, nil
+}
+
+// Publish implements publish.Interface.
+func (t *ocpPublisher) Publish(ctx context.Context, br build.Result, s string) (name.Reference, error) {
+	return t.inner.Publish(ctx, br, s)
+}
+
+func (t *ocpPublisher) Close() error {
+	if err := t.tunnel.Kill(); err != nil {
+		return fmt.Errorf("failed to kill tunnel process: %w", err)
+	}
+	if _, err := t.tunnel.Wait(); err != nil {
+		return fmt.Errorf("tunnel process didn't exit cleanly: %w", err)
+	}
+	return t.inner.Close()
+}
+
+// runOc is a helper that runs the given command with `oc` and returns the result as a
+// trimmed string.
+func runOc(args ...string) (string, error) {
+	raw, err := exec.Command("oc", args...).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(raw)), nil
+}

--- a/pkg/publish/openshift.go
+++ b/pkg/publish/openshift.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/ko/pkg/build"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 const (
@@ -66,7 +67,7 @@ func NewOpenShiftPublisher(namer Namer, tags []string) (Interface, error) {
 	// Note: port-forward is a privileged operation on Openshift, so we build an pipe
 	//       tunnel using a socat pod and attaching to its pipes.
 	//nolint:gosec // Launching this command with the output of the registry call above.
-	tunnel := exec.Command("oc", "run", "registry-tunnel", "--rm", "-i", "--image", "alpine/socat", "--", "-", "TCP4:"+registryHostPort)
+	tunnel := exec.Command("oc", "run", "registry-tunnel-"+rand.String(10), "--rm", "-i", "--image", "alpine/socat", "--", "-", "TCP4:"+registryHostPort)
 	in, err := tunnel.StdinPipe()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tunnel stdin: %w", err)

--- a/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rand provides utilities related to randomization.
+package rand
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var rng = struct {
+	sync.Mutex
+	rand *rand.Rand
+}{
+	rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+}
+
+// Int returns a non-negative pseudo-random int.
+func Int() int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int()
+}
+
+// Intn generates an integer in range [0,max).
+// By design this should panic if input is invalid, <= 0.
+func Intn(max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max)
+}
+
+// IntnRange generates an integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func IntnRange(min, max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max-min) + min
+}
+
+// IntnRange generates an int64 integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func Int63nRange(min, max int64) int64 {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int63n(max-min) + min
+}
+
+// Seed seeds the rng with the provided seed.
+func Seed(seed int64) {
+	rng.Lock()
+	defer rng.Unlock()
+
+	rng.rand = rand.New(rand.NewSource(seed))
+}
+
+// Perm returns, as a slice of n ints, a pseudo-random permutation of the integers [0,n)
+// from the default Source.
+func Perm(n int) []int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Perm(n)
+}
+
+const (
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	alphanums = "bcdfghjklmnpqrstvwxz2456789"
+	// No. of bits required to index into alphanums string.
+	alphanumsIdxBits = 5
+	// Mask used to extract last alphanumsIdxBits of an int.
+	alphanumsIdxMask = 1<<alphanumsIdxBits - 1
+	// No. of random letters we can extract from a single int63.
+	maxAlphanumsPerInt = 63 / alphanumsIdxBits
+)
+
+// String generates a random alphanumeric string, without vowels, which is n
+// characters long.  This will panic if n is less than zero.
+// How the random string is created:
+// - we generate random int63's
+// - from each int63, we are extracting multiple random letters by bit-shifting and masking
+// - if some index is out of range of alphanums we neglect it (unlikely to happen multiple times in a row)
+func String(n int) string {
+	b := make([]byte, n)
+	rng.Lock()
+	defer rng.Unlock()
+
+	randomInt63 := rng.rand.Int63()
+	remaining := maxAlphanumsPerInt
+	for i := 0; i < n; {
+		if remaining == 0 {
+			randomInt63, remaining = rng.rand.Int63(), maxAlphanumsPerInt
+		}
+		if idx := int(randomInt63 & alphanumsIdxMask); idx < len(alphanums) {
+			b[i] = alphanums[idx]
+			i++
+		}
+		randomInt63 >>= alphanumsIdxBits
+		remaining--
+	}
+	return string(b)
+}
+
+// SafeEncodeString encodes s using the same characters as rand.String. This reduces the chances of bad words and
+// ensures that strings generated from hash functions appear consistent throughout the API.
+func SafeEncodeString(s string) string {
+	r := make([]byte, len(s))
+	for i, b := range []rune(s) {
+		r[i] = alphanums[(int(b) % len(alphanums))]
+	}
+	return string(r)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -297,6 +297,7 @@ gopkg.in/yaml.v3
 k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/selection
 k8s.io/apimachinery/pkg/util/errors
+k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/util/validation
 k8s.io/apimachinery/pkg/util/validation/field


### PR DESCRIPTION
This adds support for Openshift's internal registry if the user specifies `ocp.local` as their docker repo. It logs into the registry, sets up a tunnel, connects to the correct port and then pushes the images "as usual" to the cluster.

This hasn't been widely discussed yet, so I don't expect it to merge timely if at all. This also serves as a prototype for more generalized tunneling support in an issue I'm just writing up.