### PR TITLE
Enable talking to tunneled registries via KO_DOCKER_REPO_ADDRESS

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -16,7 +16,7 @@ jobs:
       REGISTRY_NAME: registry.local
       REGISTRY_PORT: 5000
       KO_DOCKER_REPO: registry.local:5000/ko
-      KO_DOCKER_REPO_HOST: 127.0.0.1:5000
+      KO_DOCKER_REPO_ADDRESS: 127.0.0.1:5000
 
     steps:
     - uses: actions/setup-go@v2
@@ -67,7 +67,7 @@ jobs:
     - name: Run Smoke Test
       run: |
         # Test with kind load
-        KO_DOCKER_REPO=kind.local KO_DOCKER_REPO_HOST= ko apply --platform=all -f ./test
+        KO_DOCKER_REPO=kind.local KO_DOCKER_REPO_ADDRESS= ko apply --platform=all -f ./test
         kubectl wait --timeout=10s --for=condition=Ready pod/kodata
         kubectl delete pod kodata
 

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -16,6 +16,7 @@ jobs:
       REGISTRY_NAME: registry.local
       REGISTRY_PORT: 5000
       KO_DOCKER_REPO: registry.local:5000/ko
+      KO_DOCKER_REPO_HOST: 127.0.0.1:5000
 
     steps:
     - uses: actions/setup-go@v2
@@ -54,10 +55,6 @@ jobs:
         # Connect the registry to the KinD network.
         docker network connect "kind" $REGISTRY_NAME
 
-        # Make the $REGISTRY_NAME -> 127.0.0.1, to tell `ko` to publish to
-        # local reigstry, even when pushing $REGISTRY_NAME:$REGISTRY_PORT/some/image
-        sudo echo "127.0.0.1 $REGISTRY_NAME" | sudo tee -a /etc/hosts
-
     - name: Wait for ready nodes
       run: |
         kubectl wait --timeout=2m --for=condition=Ready nodes --all
@@ -70,7 +67,7 @@ jobs:
     - name: Run Smoke Test
       run: |
         # Test with kind load
-        KO_DOCKER_REPO=kind.local ko apply --platform=all -f ./test
+        KO_DOCKER_REPO=kind.local KO_DOCKER_REPO_HOST= ko apply --platform=all -f ./test
         kubectl wait --timeout=10s --for=condition=Ready pod/kodata
         kubectl delete pod kodata
 

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -81,6 +81,10 @@ jobs:
       run: |
         set -o pipefail
 
+        # Make the $REGISTRY_NAME -> 127.0.0.1, to tell `cosign` to fetch from
+        # local registry, even when fetching $REGISTRY_NAME:$REGISTRY_PORT/some/image
+        sudo echo "127.0.0.1 $REGISTRY_NAME" | sudo tee -a /etc/hosts
+
         IMAGE=$(ko build ./test)
         SBOM=$(cosign download sbom ${IMAGE})
         KO_DEPS=$(ko deps ${IMAGE})

--- a/pkg/commands/options/publish.go
+++ b/pkg/commands/options/publish.go
@@ -33,10 +33,10 @@ type PublishOptions struct {
 	// In normal ko usage, this is populated with the value of $KO_DOCKER_REPO.
 	DockerRepo string
 
-	// DockerRepoHost configures the host at which the registry can be reached. This can
+	// DockerRepoAddress configures the host at which the registry can be reached. This can
 	// differ from DockerRepo if the registry is talked to through a tunnel for example.
 	// If empty, this will be inferred from DockerRepo.
-	DockerRepoHost string
+	DockerRepoAddress string
 
 	// LocalDomain overrides the default domain for images loaded into the local Docker daemon. Use with Local=true.
 	LocalDomain string
@@ -78,8 +78,8 @@ func AddPublishArg(cmd *cobra.Command, po *PublishOptions) {
 	if dockerRepo, exists := os.LookupEnv("KO_DOCKER_REPO"); exists {
 		po.DockerRepo = dockerRepo
 	}
-	if dockerRepoHost, exists := os.LookupEnv("KO_DOCKER_REPO_HOST"); exists {
-		po.DockerRepoHost = dockerRepoHost
+	if dockerRepoHost, exists := os.LookupEnv("KO_DOCKER_REPO_ADDRESS"); exists {
+		po.DockerRepoAddress = dockerRepoHost
 	}
 
 	cmd.Flags().StringSliceVarP(&po.Tags, "tags", "t", []string{"latest"},

--- a/pkg/commands/options/publish.go
+++ b/pkg/commands/options/publish.go
@@ -33,6 +33,11 @@ type PublishOptions struct {
 	// In normal ko usage, this is populated with the value of $KO_DOCKER_REPO.
 	DockerRepo string
 
+	// DockerRepoHost configures the host at which the registry can be reached. This can
+	// differ from DockerRepo if the registry is talked to through a tunnel for example.
+	// If empty, this will be inferred from DockerRepo.
+	DockerRepoHost string
+
 	// LocalDomain overrides the default domain for images loaded into the local Docker daemon. Use with Local=true.
 	LocalDomain string
 
@@ -72,6 +77,9 @@ func AddPublishArg(cmd *cobra.Command, po *PublishOptions) {
 	// See https://github.com/google/ko/pull/351 for flag discussion.
 	if dockerRepo, exists := os.LookupEnv("KO_DOCKER_REPO"); exists {
 		po.DockerRepo = dockerRepo
+	}
+	if dockerRepoHost, exists := os.LookupEnv("KO_DOCKER_REPO_HOST"); exists {
+		po.DockerRepoHost = dockerRepoHost
 	}
 
 	cmd.Flags().StringSliceVarP(&po.Tags, "tags", "t", []string{"latest"},

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -215,13 +215,18 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 			userAgent = po.UserAgent
 		}
 		if po.Push {
-			dp, err := publish.NewDefault(repoName,
+			opts := []publish.Option{
 				publish.WithUserAgent(userAgent),
 				publish.WithAuthFromKeychain(authn.DefaultKeychain),
 				publish.WithNamer(namer),
 				publish.WithTags(po.Tags),
 				publish.WithTagOnly(po.TagOnly),
-				publish.Insecure(po.InsecureRegistry))
+				publish.Insecure(po.InsecureRegistry),
+			}
+			if po.DockerRepoHost != "" {
+				opts = append(opts, publish.WithExplicitRepoHost(po.DockerRepoHost))
+			}
+			dp, err := publish.NewDefault(repoName, opts...)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/publish/options.go
+++ b/pkg/publish/options.go
@@ -15,10 +15,8 @@
 package publish
 
 import (
-	"context"
 	"crypto/tls"
 	"log"
-	"net"
 	"net/http"
 	"path"
 
@@ -119,27 +117,6 @@ func Insecure(b bool) Option {
 		t.TLSClientConfig.InsecureSkipVerify = b //nolint: gosec
 		i.t = t
 
-		return nil
-	}
-}
-
-// WithExplicitRepoHost is a functional option for pinning the repository to a specific
-// host, for example if the repository is talked to through a local tunnel.
-func WithExplicitRepoHost(host string) Option {
-	return func(i *defaultOpener) error {
-		t, ok := i.t.(*http.Transport)
-		if !ok {
-			return nil
-		}
-		t = t.Clone()
-
-		log.Printf("Explicitly connecting to registry: %s", host)
-		dialer := t.DialContext
-		t.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
-			return dialer(ctx, network, host)
-		}
-
-		i.t = t
 		return nil
 	}
 }

--- a/pkg/publish/options.go
+++ b/pkg/publish/options.go
@@ -133,6 +133,7 @@ func WithExplicitRepoHost(host string) Option {
 		}
 		t = t.Clone()
 
+		log.Printf("Explicitly connecting to registry: %s", host)
 		dialer := t.DialContext
 		t.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
 			return dialer(ctx, network, host)


### PR DESCRIPTION
**Note:** The issue hasn't been discussed and/or accepted yet, so I'm happy to bin this if not deemed useful. I just had a good flow 😂 
**Note 2:** Will think about tests if this is deemed useful and we want to move forward with it.

Fixes https://github.com/google/ko/issues/515 (without the Bonus)

This adds a new `KO_DOCKER_REPO_HOST` environment variable that, if set, forces the publisher to connect to that exact host. This can be used to connect to `localhost:5000` (for example to a tunnel) even if the registry is something like `my-registry.my-namespace.svc:8888` (in a K8s cluster for example). The env vars used in this example would be

```
export KO_DOCKER_REPO=my-registry.my-namespace.svc:8888
export KO_DOCKER_REPO_HOST=localhost:5000
```