### PR TITLE
Run golangci-lint before tool setup to fix tar errors

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -71,6 +71,10 @@ jobs:
           go-version: 1.17.x
       - uses: actions/checkout@v2
 
+      - uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.43
+
       - name: Install Tools
         env:
           WOKE_VERSION: v0.5.0
@@ -91,10 +95,6 @@ jobs:
           echo '::endgroup::'
 
           echo "${TEMP_PATH}" >> $GITHUB_PATH
-
-      - uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.43
 
       - name: misspell
         if: ${{ always() }}


### PR DESCRIPTION
We did the same in knative/.github. The `tar` errors are due to Golang packages already existing due to the `go get` or `go install` calls.