### PR TITLE
Update golangci-lint and fix issues

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -94,7 +94,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.38
+          version: v1.43
 
       - name: misspell
         if: ${{ always() }}

--- a/pkg/commands/delete.go
+++ b/pkg/commands/delete.go
@@ -36,6 +36,7 @@ func passthru(command string) runCmd {
 
 		// Start building a command line invocation by passing
 		// through our arguments to command's CLI.
+		//nolint:gosec // We actively want to pass arguments through, so this is fine.
 		ecmd := exec.CommandContext(ctx, command, os.Args[1:]...)
 
 		// Pass through our environment


### PR DESCRIPTION
The version currently used is kinda old, so this bumps it and fixes an existing warning that was annoying me locally, while developing with a newer version 😅 