### PR TITLE
Remove special-case logic for setting Windows entrypoint paths

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -52,6 +52,9 @@ jobs:
         testimg=$(go run ./ build ./test --platform=${PLATFORM} --preserve-import-paths)
         docker run ${testimg} --wait=false 2>&1 | grep "Hello there"
 
+        # Run the image with entrypoint to ensure the binary is on PATH.
+        docker run --entrypoint=test ${testimg} --wait=false
+
         # Check that symlinks in kodata are chased.
         # Skip this test on Windows.
         if [[ "$RUNNER_OS" == "Linux" ]]; then

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -754,14 +754,9 @@ func (g *gobuild) buildOne(ctx context.Context, refStr string, base v1.Image, pl
 
 	cfg = cfg.DeepCopy()
 	cfg.Config.Entrypoint = []string{appPath}
-	if platform.OS == "windows" {
-		cfg.Config.Entrypoint = []string{`C:\ko-app\` + appFilename(ref.Path())}
-		updatePath(cfg, `C:\ko-app`)
-		cfg.Config.Env = append(cfg.Config.Env, `KO_DATA_PATH=C:\var\run\ko`)
-	} else {
-		updatePath(cfg, appDir)
-		cfg.Config.Env = append(cfg.Config.Env, "KO_DATA_PATH="+kodataRoot)
-	}
+	updatePath(cfg, appDir)
+	cfg.Config.Env = append(cfg.Config.Env, "KO_DATA_PATH="+kodataRoot)
+
 	cfg.Author = "github.com/google/ko"
 
 	if cfg.Config.Labels == nil {


### PR DESCRIPTION
This is apparently not needed, as Windows container runtimes will also
support values using standard Linux paths.

Passing Windows e2e tests should ensure this isn't a regression.