### PR TITLE
Set config creation time without mutating

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -773,7 +773,10 @@ func (g *gobuild) buildOne(ctx context.Context, refStr string, base v1.Image, pl
 		cfg.Config.Labels[k] = v
 	}
 
-	cfg.Created = g.creationTime
+	empty := v1.Time{}
+	if g.creationTime != empty {
+		cfg.Created = g.creationTime
+	}
 
 	image, err := mutate.ConfigFile(withApp, cfg)
 	if err != nil {


### PR DESCRIPTION
This also sets layers' history creation times to the relevant times set in the tar files.