### PR TITLE
Add a workflow to push a :latest ko image to ghcr.io

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,0 +1,25 @@
+name: image
+
+on:
+  push:
+    branches: ['main']
+  workflow_dispatch:
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.17.x
+
+      # Build ko from HEAD, setup auth to ghcr.io, build and push an image
+      # tagged with the SHA.
+      - name: Build and publish image
+        env:
+          KO_DOCKER_REPO: ghcr.io/${{ github.repository }}
+        run: |
+          go build ./
+          echo "${{ github.token }}" | ./ko login ghcr.io --username "dummy" --password-stdin
+          ./ko build --bare --platform=all -t latest -t ${{ github.sha }} ./

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -22,4 +22,4 @@ jobs:
         run: |
           go build ./
           echo "${{ github.token }}" | ./ko login ghcr.io --username "${{ github.actor }}" --password-stdin
-          ./ko build --bare --platform=all -t latest -t ${{ github.sha }} ./
+          ./ko build --bare --platform=all -t latest -t ${{ github.sha }} .

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           go-version: 1.17.x
 
-      # Build ko from HEAD, setup auth to ghcr.io, build and push an image
+      # Build ko from HEAD, set up auth to ghcr.io, build and push an image
       # tagged with the SHA.
       - name: Build and publish image
         env:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -21,5 +21,5 @@ jobs:
           KO_DOCKER_REPO: ghcr.io/${{ github.repository }}
         run: |
           go build ./
-          echo "${{ github.token }}" | ./ko login ghcr.io --username "dummy" --password-stdin
+          echo "${{ github.token }}" | ./ko login ghcr.io --username "${{ github.actor }}" --password-stdin
           ./ko build --bare --platform=all -t latest -t ${{ github.sha }} ./


### PR DESCRIPTION
This also tags images with the commit SHA.

In my fork:
- run: https://github.com/imjasonh/ko/runs/4473935758?check_suite_focus=true
- package UI: https://github.com/imjasonh/ko/pkgs/container/ko
- image: `ghcr.io/imjasonh/ko:12ebaefe87c83c062df6a55c452d5fb247324bca`

If this goes well we can also tag images at release-time.

Not documenting in the README in this PR since I want to get more miles on it before we recommend it to people.