### PR TITLE
Add .ko.yaml to base ko container image on golang:1.17

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,6 +33,9 @@ jobs:
         eval $(go env | sed -r 's/^(set )?(\w+)=("?)(.*)\3$/\2="\4"/gm')
 
         if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
+          # Always use the nanoserver base image, which matches the Windows
+          # version used by the GitHub Actions Windows runner.
+          rm .ko.yaml
           export KO_DEFAULTBASEIMAGE=mcr.microsoft.com/windows/nanoserver:1809
         fi
 

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,2 @@
+baseImageOverrides:
+  github.com/google/ko: golang:1.17

--- a/README.md
+++ b/README.md
@@ -466,8 +466,10 @@ You can try out building a Windows container image by [setting the base image](#
 For example, to build a Windows container image for `ko`, from within this repo:
 
 ```
-KO_DEFAULTBASEIMAGE=mcr.microsoft.com/windows/nanoserver:1809 ko publish ./ --platform=windows/amd64
+ko publish ./ --platform=windows/amd64
 ```
+
+This works because the `ko` image is configured in [`.ko.yaml`](./.ko.yaml) to be based on a `golang` base image, which provides platform-specific images for both Linux and Windows.
 
 ### Known issues 🐛
 


### PR DESCRIPTION
```
$ img=$(ko build ./)
...
$ docker run --rm \
  --volume $(pwd):/src \
  --workdir /src \
  --volume ~/.docker:/root/.docker \
  -e KO_DOCKER_REPO=quay.io/imjasonh \
  ${img} \
  build ./ \
  --sbom=none
...
quay.io/imjasonh/ko-98b8c7facdad74510a7cae0cd368eb4e@sha256:7c4c064d8ca7880b4a98674201b2c5e7c6df7fb536b5f4a470acce1a9f75f14b
```

(Pushing to quay.io since I don't have it configured to use a cred helper, which makes demonstrating this more annoying -- this also exposed https://github.com/google/ko/issues/532, which is why I'm testing with `--sbom=none`)

When we have the image pushed and tagged in the release we should add documentation for this usage in the README.