### PR TITLE
Support osversion when selecting base images

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,7 +35,7 @@ jobs:
         export PLATFORM=${GOOS}/${GOARCH}
 
         if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
-          OSVERSION="10.0.17763.2300"
+          OSVERSION="10.0.17763.2366"
           PLATFORM=${PLATFORM}:${OSVERSION}
           export KO_DEFAULTBASEIMAGE=mcr.microsoft.com/windows/nanoserver:1809
         else

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,7 +1,7 @@
 name: Basic e2e test
 
 on:
-  pull_request: 
+  pull_request:
     branches: ['main']
 
 jobs:
@@ -35,9 +35,8 @@ jobs:
         export PLATFORM=${GOOS}/${GOARCH}
 
         if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
-          # Always use the nanoserver base image, which matches the Windows
-          # version used by the GitHub Actions Windows runner.
-          rm .ko.yaml
+          OSVERSION="10.0.17763.2300"
+          PLATFORM=${PLATFORM}:${OSVERSION}
           export KO_DEFAULTBASEIMAGE=mcr.microsoft.com/windows/nanoserver:1809
         else
           # Explicitly test multiple platform builds (a subset of what's in the base!)

--- a/pkg/commands/config_test.go
+++ b/pkg/commands/config_test.go
@@ -41,9 +41,10 @@ func TestOverrideDefaultBaseImageUsingBuildOption(t *testing.T) {
 	wantImage := fmt.Sprintf("%s@%s", baseImage, wantDigest)
 	bo := &options.BuildOptions{
 		BaseImage: wantImage,
+		Platform:  "all",
 	}
 
-	baseFn := getBaseImage("all", bo)
+	baseFn := getBaseImage(bo)
 	_, res, err := baseFn(context.Background(), "ko://example.com/helloworld")
 	if err != nil {
 		t.Fatalf("getBaseImage(): %v", err)

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -61,20 +61,19 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 		return nil, err
 	}
 
-	platform := bo.Platform
-	if platform == "" {
-		platform = "linux/amd64"
+	if bo.Platform == "" {
+		bo.Platform = "linux/amd64"
 
 		goos, goarch, goarm := os.Getenv("GOOS"), os.Getenv("GOARCH"), os.Getenv("GOARM")
 
 		// Default to linux/amd64 unless GOOS and GOARCH are set.
 		if goos != "" && goarch != "" {
-			platform = path.Join(goos, goarch)
+			bo.Platform = path.Join(goos, goarch)
 		}
 
 		// Use GOARM for variant if it's set and GOARCH is arm.
 		if strings.Contains(goarch, "arm") && goarm != "" {
-			platform = path.Join(platform, "v"+goarm)
+			bo.Platform = path.Join(bo.Platform, "v"+goarm)
 		}
 	} else {
 		// Make sure these are all unset
@@ -86,8 +85,8 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 	}
 
 	opts := []build.Option{
-		build.WithBaseImages(getBaseImage(platform, bo)),
-		build.WithPlatforms(platform),
+		build.WithBaseImages(getBaseImage(bo)),
+		build.WithPlatforms(bo.Platform),
 		build.WithJobs(bo.ConcurrentBuilds),
 	}
 	if creationTime != nil {


### PR DESCRIPTION
Fixes #534 

This builds on #533 to add an option to the `--platform` flag to explicitly select a platform by osversion, which happens to be necessary to select the correct `golang:1.17` base image for the GitHub Actions runner environment.