### PR TITLE
cleanup: Remove publisher.Close method

### DIFF
--- a/pkg/commands/apply.go
+++ b/pkg/commands/apply.go
@@ -96,7 +96,6 @@ func addApply(topLevel *cobra.Command) {
 			if err != nil {
 				return fmt.Errorf("error creating publisher: %w", err)
 			}
-			defer publisher.Close()
 
 			// Issue a "kubectl apply" command reading from stdin,
 			// to which we will pipe the resolved files, and any

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -69,7 +69,6 @@ func addBuild(topLevel *cobra.Command) {
 			if err != nil {
 				return fmt.Errorf("error creating publisher: %w", err)
 			}
-			defer publisher.Close()
 			images, err := publishImages(ctx, args, publisher, builder)
 			if err != nil {
 				return fmt.Errorf("failed to publish images: %w", err)

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -81,7 +81,6 @@ func addCreate(topLevel *cobra.Command) {
 			if err != nil {
 				return fmt.Errorf("error creating publisher: %w", err)
 			}
-			defer publisher.Close()
 
 			// Issue a "kubectl create" command reading from stdin,
 			// to which we will pipe the resolved files, and any

--- a/pkg/commands/resolve.go
+++ b/pkg/commands/resolve.go
@@ -66,7 +66,6 @@ func addResolve(topLevel *cobra.Command) {
 			if err != nil {
 				return fmt.Errorf("error creating publisher: %w", err)
 			}
-			defer publisher.Close()
 			return resolveFilesToWriter(ctx, builder, publisher, fo, so, os.Stdout)
 		},
 	}

--- a/pkg/commands/resolver_test.go
+++ b/pkg/commands/resolver_test.go
@@ -285,7 +285,6 @@ func TestNewPublisherCanPublish(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewPublisher(): %v", err)
 			}
-			defer publisher.Close()
 			ref, err := publisher.Publish(context.Background(), empty.Image, build.StrictScheme+importpath)
 			if test.shouldError {
 				if err == nil || !strings.HasSuffix(err.Error(), test.wantError.Error()) {

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -76,7 +76,6 @@ func addRun(topLevel *cobra.Command) {
 			if err != nil {
 				return fmt.Errorf("error creating publisher: %w", err)
 			}
-			defer publisher.Close()
 
 			if len(os.Args) < 3 {
 				return fmt.Errorf("usage: %s run <package>", os.Args[0])

--- a/pkg/publish/daemon.go
+++ b/pkg/publish/daemon.go
@@ -166,7 +166,3 @@ func (d *demon) Publish(ctx context.Context, br build.Result, s string) (name.Re
 
 	return &digestTag, nil
 }
-
-func (d *demon) Close() error {
-	return nil
-}

--- a/pkg/publish/default.go
+++ b/pkg/publish/default.go
@@ -254,7 +254,3 @@ func (d *defalt) Publish(ctx context.Context, br build.Result, s string) (name.R
 	log.Printf("Published %v", dig)
 	return &dig, nil
 }
-
-func (d *defalt) Close() error {
-	return nil
-}

--- a/pkg/publish/kind.go
+++ b/pkg/publish/kind.go
@@ -122,7 +122,3 @@ func (t *kindPublisher) Publish(ctx context.Context, br build.Result, s string) 
 
 	return &digestTag, nil
 }
-
-func (t *kindPublisher) Close() error {
-	return nil
-}

--- a/pkg/publish/layout.go
+++ b/pkg/publish/layout.go
@@ -87,7 +87,3 @@ func (l *LayoutPublisher) Publish(_ context.Context, br build.Result, s string) 
 
 	return dig, nil
 }
-
-func (l *LayoutPublisher) Close() error {
-	return nil
-}

--- a/pkg/publish/multi.go
+++ b/pkg/publish/multi.go
@@ -49,12 +49,3 @@ func (p *multiPublisher) Publish(ctx context.Context, br build.Result, s string)
 	}
 	return
 }
-
-func (p *multiPublisher) Close() (err error) {
-	for _, pub := range p.publishers {
-		if perr := pub.Close(); perr != nil {
-			err = perr
-		}
-	}
-	return
-}

--- a/pkg/publish/multi_test.go
+++ b/pkg/publish/multi_test.go
@@ -58,10 +58,6 @@ func TestMulti(t *testing.T) {
 	if _, err := p.Publish(context.Background(), img, importpath); err != nil {
 		t.Errorf("Publish() = %v", err)
 	}
-
-	if err := p.Close(); err != nil {
-		t.Errorf("Close() = %v", err)
-	}
 }
 
 func TestMulti_Zero(t *testing.T) {

--- a/pkg/publish/publish.go
+++ b/pkg/publish/publish.go
@@ -27,8 +27,4 @@ type Interface interface {
 	// provided string into the image's repository name.  Returns the digest
 	// of the published image.
 	Publish(context.Context, build.Result, string) (name.Reference, error)
-
-	// Close exists for the tarball implementation so we can
-	// do the whole thing in one write.
-	Close() error
 }

--- a/pkg/publish/shared.go
+++ b/pkg/publish/shared.go
@@ -75,7 +75,3 @@ func (c *caching) Publish(ctx context.Context, br build.Result, ref string) (nam
 
 	return f.Get()
 }
-
-func (c *caching) Close() error {
-	return c.inner.Close()
-}

--- a/pkg/publish/shared_test.go
+++ b/pkg/publish/shared_test.go
@@ -36,10 +36,6 @@ func (sp *slowpublish) Publish(_ context.Context, br build.Result, ref string) (
 	return makeRef()
 }
 
-func (sp *slowpublish) Close() error {
-	return nil
-}
-
 func TestCaching(t *testing.T) {
 	duration := 100 * time.Millisecond
 	ref := "foo"

--- a/pkg/publish/tarball.go
+++ b/pkg/publish/tarball.go
@@ -80,8 +80,6 @@ func (t *tar) Publish(_ context.Context, br build.Result, s string) (name.Refere
 
 	log.Printf("Saving %v", t.file)
 	if err := tarball.MultiRefWriteToFile(t.file, t.refs); err != nil {
-		// Bad practice, but we log  this here because right now we just defer the Close.
-		log.Printf("failed to save %q: %v", t.file, err)
 		return nil, err
 	}
 	log.Printf("Saved %v", t.file)

--- a/pkg/publish/tarball.go
+++ b/pkg/publish/tarball.go
@@ -78,6 +78,14 @@ func (t *tar) Publish(_ context.Context, br build.Result, s string) (name.Refere
 		t.refs[ref] = img
 	}
 
+	log.Printf("Saving %v", t.file)
+	if err := tarball.MultiRefWriteToFile(t.file, t.refs); err != nil {
+		// Bad practice, but we log  this here because right now we just defer the Close.
+		log.Printf("failed to save %q: %v", t.file, err)
+		return nil, err
+	}
+	log.Printf("Saved %v", t.file)
+
 	ref := fmt.Sprintf("%s@%s", t.namer(t.base, s), h)
 	if len(t.tags) == 1 && t.tags[0] != defaultTags[0] {
 		// If a single tag is explicitly set (not latest), then this
@@ -90,15 +98,4 @@ func (t *tar) Publish(_ context.Context, br build.Result, s string) (name.Refere
 	}
 
 	return &dig, nil
-}
-
-func (t *tar) Close() error {
-	log.Printf("Saving %v", t.file)
-	if err := tarball.MultiRefWriteToFile(t.file, t.refs); err != nil {
-		// Bad practice, but we log  this here because right now we just defer the Close.
-		log.Printf("failed to save %q: %v", t.file, err)
-		return err
-	}
-	log.Printf("Saved %v", t.file)
-	return nil
 }


### PR DESCRIPTION
This was nearly always only implemented `return nil`, and the one case it wasn't (tarball publishing), it didn't do anything that needed to be done in `Close` anyway. This simplifies the interface, making it harder to accidentally forget to call `defer publisher.Close()` and wonder whether you're leaking resources.

This also removes a `bad practice` in pkg/publish/tarball.go which was only done because we were `defer`ring `Close()`.