### PR TITLE
Fix #530 Hanging behavior with ASDF installed Go on Darwin

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -161,9 +161,13 @@ func NewGo(ctx context.Context, dir string, options ...Option) (Interface, error
 }
 
 func (g *gobuild) qualifyLocalImport(importpath string) (string, error) {
+	dir := g.dir
+	if filepath.Clean(g.dir) == "." {
+		dir = ""
+	}
 	cfg := &packages.Config{
 		Mode: packages.NeedName,
-		Dir:  g.dir,
+		Dir:  dir,
 	}
 	pkgs, err := packages.Load(cfg, importpath)
 	if err != nil {
@@ -199,7 +203,11 @@ func (g *gobuild) IsSupportedReference(s string) error {
 	if !ref.IsStrict() {
 		return errors.New("importpath does not start with ko://")
 	}
-	pkgs, err := packages.Load(&packages.Config{Dir: g.dir, Mode: packages.NeedName}, ref.Path())
+	dir := g.dir
+	if filepath.Clean(g.dir) == "." {
+		dir = ""
+	}
+	pkgs, err := packages.Load(&packages.Config{Dir: dir, Mode: packages.NeedName}, ref.Path())
 	if err != nil {
 		return fmt.Errorf("error loading package from %s: %w", ref.Path(), err)
 	}
@@ -440,7 +448,11 @@ func tarBinary(name, binary string, creationTime v1.Time, platform *v1.Platform)
 }
 
 func (g *gobuild) kodataPath(ref reference) (string, error) {
-	pkgs, err := packages.Load(&packages.Config{Dir: g.dir, Mode: packages.NeedFiles}, ref.Path())
+	dir := g.dir
+	if filepath.Clean(g.dir) == "." {
+		dir = ""
+	}
+	pkgs, err := packages.Load(&packages.Config{Dir: dir, Mode: packages.NeedFiles}, ref.Path())
 	if err != nil {
 		return "", fmt.Errorf("error loading package from %s: %w", ref.Path(), err)
 	}

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -180,8 +180,11 @@ func createBuildConfigMap(workingDirectory string, configs []build.Config) (map[
 		// local import paths, therefore add a "./" equivalent as a prefix to
 		// the constructured import path
 		localImportPath := fmt.Sprint(".", string(filepath.Separator), path)
-
-		pkgs, err := packages.Load(&packages.Config{Mode: packages.NeedName, Dir: baseDir}, localImportPath)
+		dir := baseDir
+		if filepath.Clean(dir) == "." {
+			dir = ""
+		}
+		pkgs, err := packages.Load(&packages.Config{Mode: packages.NeedName, Dir: dir}, localImportPath)
 		if err != nil {
 			return nil, fmt.Errorf("'builds': entry #%d does not contain a valid local import path (%s) for directory (%s): %w", i, localImportPath, baseDir, err)
 		}


### PR DESCRIPTION
So this resolves the issue with ko hanging  on Darwin when Go is installed using ASDF, however, I'm not sure if this is the final fix that still works for everyone else.

@jonjohnsonjr 
Signed-off-by: Steve Coffman <steve@khanacademy.org>