### PR TITLE
Prepare for Go 1.18 by replacing all our forked code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,14 +7,29 @@ on:
 jobs:
 
   build:
-    name: Build
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ['1.17.x', '1.18.x']
+    name: Build ${{ matrix.go-version }}
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          # TODO: when 1.18 is released, just make this
+          # ${{ matrix.go-version }} and delete the next step.
+          go-version: '1.17.x'
+
+      # Use the installed Go version to download and install the latest 1.18
+      # beta and replace our existing go with that one.
+      - if: ${{ matrix.go-version == '1.18.x' }}
+        run: |
+          go install golang.org/dl/go1.18beta1@latest
+          go1.18beta1 download
+          cp $(which go1.18beta1) $(which go)
+          go version
 
       - run: |
           go build ./...

--- a/internal/sbom/mod.go
+++ b/internal/sbom/mod.go
@@ -1,3 +1,5 @@
+// +build !go1.18
+
 // Copyright 2021 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/sbom/mod.go
+++ b/internal/sbom/mod.go
@@ -1,3 +1,4 @@
+//go:build !go1.18
 // +build !go1.18
 
 // Copyright 2021 Google LLC All Rights Reserved.

--- a/internal/sbom/mod_1.18.go
+++ b/internal/sbom/mod_1.18.go
@@ -1,13 +1,27 @@
+//go:build go1.18
 // +build go1.18
+
+// Copyright 2021 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package sbom
 
 import (
-	"debug/buildinfo"
 	"runtime/debug"
 )
 
-type BuildInfo buildinfo.BuildInfo
+type BuildInfo debug.BuildInfo
 
 func (bi *BuildInfo) UnmarshalText(data []byte) error {
 	dbi := (*debug.BuildInfo)(bi)

--- a/internal/sbom/mod_1.18.go
+++ b/internal/sbom/mod_1.18.go
@@ -1,0 +1,19 @@
+// +build go1.18
+
+package sbom
+
+import (
+	"debug/buildinfo"
+	"runtime/debug"
+)
+
+type BuildInfo buildinfo.BuildInfo
+
+func (bi *BuildInfo) UnmarshalText(data []byte) error {
+	dbi := (*debug.BuildInfo)(bi)
+	if err := dbi.UnmarshalText(data); err != nil {
+		return err
+	}
+	bi = (*BuildInfo)(dbi)
+	return nil
+}


### PR DESCRIPTION
This hides our forked-from-gotip code behind a build tag so it's only
used when the build is run on Go <1.18. For builds >= 1.18, we'll use
the actual runtime/debug and debug/buildinfo packages.

Add preliminary support for building on Go 1.18beta1 to our Build
matrix, to ensure this code builds. It's all a terrible hack, but it'll
get less so when 1.18 is actually released.

(If we'd rather wait until 1.18 is actually released that's fine by me, this can wait.)