### PR TITLE
Pre-parse platform string with StringSliceVar

### DIFF
--- a/doc/ko_apply.md
+++ b/doc/ko_apply.md
@@ -67,7 +67,7 @@ ko apply -f FILENAME [flags]
   -n, --namespace string               If present, the namespace scope for this CLI request (DEPRECATED)
       --oci-layout-path string         Path to save the OCI image layout of the built images
       --password string                Password for basic authentication to the API server (DEPRECATED)
-      --platform string                Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+      --platform strings               Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths          Whether to preserve the full import path after KO_DOCKER_REPO.
       --push                           Push images to KO_DOCKER_REPO (default true)
   -R, --recursive                      Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.

--- a/doc/ko_build.md
+++ b/doc/ko_build.md
@@ -52,7 +52,7 @@ ko build IMPORTPATH... [flags]
   -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
   -L, --local                    Load into images to local docker daemon.
       --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform string          Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
       --push                     Push images to KO_DOCKER_REPO (default true)
       --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m). (default "spdx")

--- a/doc/ko_create.md
+++ b/doc/ko_create.md
@@ -67,7 +67,7 @@ ko create -f FILENAME [flags]
   -n, --namespace string               If present, the namespace scope for this CLI request (DEPRECATED)
       --oci-layout-path string         Path to save the OCI image layout of the built images
       --password string                Password for basic authentication to the API server (DEPRECATED)
-      --platform string                Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+      --platform strings               Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths          Whether to preserve the full import path after KO_DOCKER_REPO.
       --push                           Push images to KO_DOCKER_REPO (default true)
   -R, --recursive                      Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.

--- a/doc/ko_resolve.md
+++ b/doc/ko_resolve.md
@@ -48,7 +48,7 @@ ko resolve -f FILENAME [flags]
   -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
   -L, --local                    Load into images to local docker daemon.
       --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform string          Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
       --push                     Push images to KO_DOCKER_REPO (default true)
   -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.

--- a/doc/ko_run.md
+++ b/doc/ko_run.md
@@ -39,7 +39,7 @@ ko run IMPORTPATH [flags]
   -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
   -L, --local                    Load into images to local docker daemon.
       --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform string          Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
       --push                     Push images to KO_DOCKER_REPO (default true)
       --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m). (default "spdx")

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -819,7 +819,7 @@ func TestGoBuildIndex(t *testing.T) {
 		"",
 		WithCreationTime(creationTime),
 		WithBaseImages(func(context.Context, string) (name.Reference, Result, error) { return baseRef, base, nil }),
-		WithPlatforms("all"),
+		WithPlatforms([]string{"all"}),
 		withBuilder(writeTempFile),
 		withSBOMber(fauxSBOM),
 	)
@@ -980,30 +980,30 @@ func TestGoarm(t *testing.T) {
 func TestMatchesPlatformSpec(t *testing.T) {
 	for _, tc := range []struct {
 		platform *v1.Platform
-		spec     string
+		spec     []string
 		result   bool
 		err      bool
 	}{{
 		platform: nil,
-		spec:     "all",
+		spec:     []string{"all"},
 		result:   true,
 	}, {
 		platform: nil,
-		spec:     "linux/amd64",
+		spec:     []string{"linux/amd64"},
 		result:   false,
 	}, {
 		platform: &v1.Platform{
 			Architecture: "amd64",
 			OS:           "linux",
 		},
-		spec:   "all",
+		spec:   []string{"all"},
 		result: true,
 	}, {
 		platform: &v1.Platform{
 			Architecture: "amd64",
 			OS:           "windows",
 		},
-		spec:   "linux",
+		spec:   []string{"linux"},
 		result: false,
 	}, {
 		platform: &v1.Platform{
@@ -1011,7 +1011,7 @@ func TestMatchesPlatformSpec(t *testing.T) {
 			OS:           "linux",
 			Variant:      "v3",
 		},
-		spec:   "linux/amd64,linux/arm64",
+		spec:   []string{"linux/amd64", "linux/arm64"},
 		result: true,
 	}, {
 		platform: &v1.Platform{
@@ -1019,7 +1019,7 @@ func TestMatchesPlatformSpec(t *testing.T) {
 			OS:           "linux",
 			Variant:      "v3",
 		},
-		spec:   "linux/amd64,linux/arm64/v4",
+		spec:   []string{"linux/amd64", "linux/arm64/v4"},
 		result: false,
 	}, {
 		platform: &v1.Platform{
@@ -1027,10 +1027,10 @@ func TestMatchesPlatformSpec(t *testing.T) {
 			OS:           "linux",
 			Variant:      "v3",
 		},
-		spec: "linux/amd64,linux/arm64/v3/z5",
+		spec: []string{"linux/amd64", "linux/arm64/v3/z5"},
 		err:  true,
 	}, {
-		spec: "",
+		spec: []string{},
 		platform: &v1.Platform{
 			Architecture: "amd64",
 			OS:           "linux",

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -819,7 +819,7 @@ func TestGoBuildIndex(t *testing.T) {
 		"",
 		WithCreationTime(creationTime),
 		WithBaseImages(func(context.Context, string) (name.Reference, Result, error) { return baseRef, base, nil }),
-		WithPlatforms([]string{"all"}),
+		WithPlatforms("all"),
 		withBuilder(writeTempFile),
 		withSBOMber(fauxSBOM),
 	)

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -89,9 +89,9 @@ func WithConfig(buildConfigs map[string]Config) Option {
 //
 // platform = <os>[/<arch>[/<variant>]]
 // allowed = all | platform[,platform]*
-func WithPlatforms(platforms string) Option {
+func WithPlatforms(platforms []string) Option {
 	return func(gbo *gobuildOpener) error {
-		gbo.platform = platforms
+		gbo.platforms = platforms
 		return nil
 	}
 }

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -15,6 +15,8 @@
 package build
 
 import (
+	"strings"
+
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
@@ -85,12 +87,20 @@ func WithConfig(buildConfigs map[string]Config) Option {
 
 // WithPlatforms is a functional option for building certain platforms for
 // multi-platform base images. To build everything from the base, use "all",
-// otherwise use a comma-separated list of platform specs, i.e.:
+// otherwise use a list of platform specs, i.e.:
 //
 // platform = <os>[/<arch>[/<variant>]]
-// allowed = all | platform[,platform]*
-func WithPlatforms(platforms []string) Option {
+// allowed = "all" | []string{platform[,platform]*}
+//
+// Note: a string of comma-separated platforms (i.e. "platform[,platform]*")
+// has been deprecated and only exist for backwards compatibility reasons,
+// which will be removed in the future.
+func WithPlatforms(platforms ...string) Option {
 	return func(gbo *gobuildOpener) error {
+		if len(platforms) == 1 {
+			// TODO: inform users that they are using deprecated flow?
+			platforms = strings.Split(platforms[0], ",")
+		}
 		gbo.platforms = platforms
 		return nil
 	}

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -61,11 +61,13 @@ func getBaseImage(bo *options.BuildOptions) build.GetBase {
 		//
 		// Platforms can be comma-separated if we only want a subset of the base
 		// image.
-		multiplatform := bo.Platform == "all" || strings.Contains(bo.Platform, ",")
-		if bo.Platform != "" && !multiplatform {
+		allPlatforms := len(bo.Platforms) == 1 && bo.Platforms[0] == "all"
+		selectiveMultiplatform := len(bo.Platforms) > 1
+		multiplatform := allPlatforms || selectiveMultiplatform
+		if len(bo.Platforms) > 0 && !multiplatform {
 			var p v1.Platform
 
-			parts := strings.Split(bo.Platform, ":")
+			parts := strings.Split(bo.Platforms[0], ":")
 			if len(parts) == 2 {
 				p.OSVersion = parts[1]
 			}
@@ -81,7 +83,7 @@ func getBaseImage(bo *options.BuildOptions) build.GetBase {
 				p.Variant = parts[2]
 			}
 			if len(parts) > 3 {
-				return nil, fmt.Errorf("too many slashes in platform spec: %s", bo.Platform)
+				return nil, fmt.Errorf("too many slashes in platform spec: %s", bo.Platforms[0])
 			}
 			ropt = append(ropt, remote.WithPlatform(p))
 		}

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -60,8 +60,7 @@ func getBaseImage(bo *options.BuildOptions) build.GetBase {
 		// otherwise we'll resolve it to the appropriate platform.
 		allPlatforms := len(bo.Platforms) == 1 && bo.Platforms[0] == "all"
 
-		// Platforms can be comma-separated if we only want a subset of the base
-		// image.
+		// Platforms can be listed in a slice if we only want a subset of the base image.
 		selectiveMultiplatform := len(bo.Platforms) > 1
 
 		multiplatform := allPlatforms || selectiveMultiplatform

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -58,15 +58,18 @@ func getBaseImage(bo *options.BuildOptions) build.GetBase {
 
 		// Using --platform=all will use an image index for the base,
 		// otherwise we'll resolve it to the appropriate platform.
-		//
+		allPlatforms := len(bo.Platforms) == 1 && bo.Platforms[0] == "all"
+
 		// Platforms can be comma-separated if we only want a subset of the base
 		// image.
-		allPlatforms := len(bo.Platforms) == 1 && bo.Platforms[0] == "all"
 		selectiveMultiplatform := len(bo.Platforms) > 1
+
 		multiplatform := allPlatforms || selectiveMultiplatform
-		if len(bo.Platforms) > 0 && !multiplatform {
+		if !multiplatform {
 			var p v1.Platform
 
+			// There is _at least_ one platform specified at this point,
+			// because receiving "" means we would infer from GOOS/GOARCH.
 			parts := strings.Split(bo.Platforms[0], ":")
 			if len(parts) == 2 {
 				p.OSVersion = parts[1]

--- a/pkg/commands/config_test.go
+++ b/pkg/commands/config_test.go
@@ -41,7 +41,7 @@ func TestOverrideDefaultBaseImageUsingBuildOption(t *testing.T) {
 	wantImage := fmt.Sprintf("%s@%s", baseImage, wantDigest)
 	bo := &options.BuildOptions{
 		BaseImage: wantImage,
-		Platform:  "all",
+		Platforms: []string{"all"},
 	}
 
 	baseFn := getBaseImage(bo)

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -51,7 +51,7 @@ type BuildOptions struct {
 	ConcurrentBuilds     int
 	DisableOptimizations bool
 	SBOM                 string
-	Platform             string
+	Platforms            []string
 	Labels               []string
 	// UserAgent enables overriding the default value of the `User-Agent` HTTP
 	// request header used when retrieving the base image.
@@ -76,7 +76,7 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"Disable optimizations when building Go code. Useful when you want to interactively debug the created container.")
 	cmd.Flags().StringVar(&bo.SBOM, "sbom", "spdx",
 		"The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m).")
-	cmd.Flags().StringVar(&bo.Platform, "platform", "",
+	cmd.Flags().StringSliceVar(&bo.Platforms, "platform", []string{},
 		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*")
 	cmd.Flags().StringSliceVar(&bo.Labels, "image-label", []string{},
 		"Which labels (key=value) to add to the image.")

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -88,7 +88,7 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 
 	opts := []build.Option{
 		build.WithBaseImages(getBaseImage(bo)),
-		build.WithPlatforms(bo.Platforms),
+		build.WithPlatforms(bo.Platforms...),
 		build.WithJobs(bo.ConcurrentBuilds),
 	}
 	if creationTime != nil {

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -61,20 +61,22 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 		return nil, err
 	}
 
-	if bo.Platform == "" {
-		bo.Platform = "linux/amd64"
+	if len(bo.Platforms) == 0 {
+		envPlatform := "linux/amd64"
 
 		goos, goarch, goarm := os.Getenv("GOOS"), os.Getenv("GOARCH"), os.Getenv("GOARM")
 
 		// Default to linux/amd64 unless GOOS and GOARCH are set.
 		if goos != "" && goarch != "" {
-			bo.Platform = path.Join(goos, goarch)
+			envPlatform = path.Join(goos, goarch)
 		}
 
 		// Use GOARM for variant if it's set and GOARCH is arm.
 		if strings.Contains(goarch, "arm") && goarm != "" {
-			bo.Platform = path.Join(bo.Platform, "v"+goarm)
+			envPlatform = path.Join(envPlatform, "v"+goarm)
 		}
+
+		bo.Platforms = append(bo.Platforms, envPlatform)
 	} else {
 		// Make sure these are all unset
 		for _, env := range []string{"GOOS", "GOARCH", "GOARM"} {
@@ -86,7 +88,7 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 
 	opts := []build.Option{
 		build.WithBaseImages(getBaseImage(bo)),
-		build.WithPlatforms(bo.Platform),
+		build.WithPlatforms(bo.Platforms),
 		build.WithJobs(bo.ConcurrentBuilds),
 	}
 	if creationTime != nil {

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -76,7 +76,7 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 			envPlatform = path.Join(envPlatform, "v"+goarm)
 		}
 
-		bo.Platforms = append(bo.Platforms, envPlatform)
+		bo.Platforms = []string{envPlatform}
 	} else {
 		// Make sure these are all unset
 		for _, env := range []string{"GOOS", "GOARCH", "GOARM"} {


### PR DESCRIPTION
Hello! First time contributing to `ko` here 👋🏼 

- The variable `BuildOptions.Platform` was renamed to `BuildOptions.Platforms` to reflect the actual data type, though I'm not sure how comfortable are we in breaking changes of (supposedly) public structs.
- I took somewhat of a "persisting structure all the way down" approach which has a side effect of `platformMatcher.spec` and `gobuildOpener.platforms` are now of type `[]string` (instead of `string`).

Happy to discuss and make changes as desired by maintainers!

Closes #537