### PR TITLE
Introduce koverrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Ignore GoLand (IntelliJ) files.
 .idea/
 
+coverage.txt
 ko

--- a/README.md
+++ b/README.md
@@ -421,6 +421,68 @@ ko delete -f config/
 This is purely a convenient alias for `kubectl delete`, and doesn't perform any
 builds, or delete any previously built images.
 
+## "koverrides"
+
+When using `ko` in the context of Kubernetes, you may wish to reuse your YAML file(s)
+across several different environments.
+
+As a lightweight solution for environment-specific configuration, you can leverage
+"koverrides" (a.k.a. `ko` overrides).
+
+Using koverrides, you can prefix values with `koverride://` and supply a default value:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo
+data:
+  db-host: koverride://db.host/mysql.default.svc
+  db-port: koverride://db.port/3306
+  db-user: koverride://db.user
+  db-pass: koverride://db.pass
+```
+
+The default value can be defined as everything after the first forward slash (`/`)
+character. If there is no default, then an empty string will be used (`""`).
+Nested keys are supported using dot (`.`) notation.
+
+Consider the following koverrides file, `demo.yaml`:
+
+```yaml
+db:
+  host: db.example.com
+  user: secretuser
+  pass: secretpass
+```
+
+Now we run `ko resolve` (or `ko apply`) using the
+`--koverrides` flag, pointing to the file:
+
+```
+ko resolve -f config/ --koverrides demo.yaml
+```
+
+Which produces the following YAML:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo
+data:
+  db-host: db.example.com
+  db-port: "3306"
+  db-user: secretuser
+  db-pass: secretpass
+```
+
+For practical purposes, all resulting values are coerced to strings
+(e.g. `3306 -> "3306"`).
+
+This feature is particularly useful for Kubernetes resource types designed
+for configuration purposes, such as ConfigMaps or Secrets.
+
 # Frequently Asked Questions
 
 ## How can I set `ldflags`?

--- a/doc/ko_apply.md
+++ b/doc/ko_apply.md
@@ -63,6 +63,7 @@ ko apply -f FILENAME [flags]
       --insecure-registry              Whether to skip TLS verification on the registry
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure (DEPRECATED)
   -j, --jobs int                       The maximum number of concurrent builds (default GOMAXPROCS)
+      --koverrides string              Filename to use for koverrides
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests. (DEPRECATED)
   -L, --local                          Load into images to local docker daemon.
   -n, --namespace string               If present, the namespace scope for this CLI request (DEPRECATED)

--- a/doc/ko_create.md
+++ b/doc/ko_create.md
@@ -63,6 +63,7 @@ ko create -f FILENAME [flags]
       --insecure-registry              Whether to skip TLS verification on the registry
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure (DEPRECATED)
   -j, --jobs int                       The maximum number of concurrent builds (default GOMAXPROCS)
+      --koverrides string              Filename to use for koverrides
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests. (DEPRECATED)
   -L, --local                          Load into images to local docker daemon.
   -n, --namespace string               If present, the namespace scope for this CLI request (DEPRECATED)

--- a/doc/ko_resolve.md
+++ b/doc/ko_resolve.md
@@ -47,6 +47,7 @@ ko resolve -f FILENAME [flags]
       --image-refs string        Path to file where a list of the published image references will be written.
       --insecure-registry        Whether to skip TLS verification on the registry
   -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
+      --koverrides string        Filename to use for koverrides
   -L, --local                    Load into images to local docker daemon.
       --oci-layout-path string   Path to save the OCI image layout of the built images
       --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -38,6 +38,11 @@ type Interface interface {
 	// TODO(mattmoor): Verify that some base repo: foo.io/bar can be suffixed with this reference and parsed.
 	IsSupportedReference(string) error
 
+	// IsSupportedOverrideReference determines whether the given value is a
+	// valid override reference that Ko supports resolving, returning an error
+	// if it is not.
+	IsSupportedOverrideReference(string) error
+
 	// Build turns the given importpath reference into a v1.Image containing the Go binary
 	// (or a set of images as a v1.ImageIndex).
 	Build(context.Context, string) (Result, error)

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -220,6 +220,17 @@ func (g *gobuild) IsSupportedReference(s string) error {
 	return nil
 }
 
+// IsSupportedOverrideReference implements build.Interface
+//
+// Value must start with koverride://.
+func (g *gobuild) IsSupportedOverrideReference(s string) error {
+	ref := newOverrideRef(s)
+	if !ref.IsStrict() {
+		return errors.New("value does not start with koverride://")
+	}
+	return nil
+}
+
 func getGoarm(platform v1.Platform) (string, error) {
 	if !strings.HasPrefix(platform.Variant, "v") {
 		return "", fmt.Errorf("strange arm variant: %v", platform.Variant)

--- a/pkg/build/gobuilds.go
+++ b/pkg/build/gobuilds.go
@@ -86,6 +86,11 @@ func (g *gobuilds) IsSupportedReference(importpath string) error {
 	return g.builder(importpath).builder.IsSupportedReference(importpath)
 }
 
+// IsSupportedOverrideReference implements build.Interface
+func (g *gobuilds) IsSupportedOverrideReference(importpath string) error {
+	return g.builder(importpath).builder.IsSupportedOverrideReference(importpath)
+}
+
 // Build implements build.Interface
 func (g *gobuilds) Build(ctx context.Context, importpath string) (Result, error) {
 	return g.builder(importpath).builder.Build(ctx, importpath)

--- a/pkg/build/limit_test.go
+++ b/pkg/build/limit_test.go
@@ -38,6 +38,11 @@ func (r *sleeper) IsSupportedReference(ip string) error {
 	return nil
 }
 
+// IsSupportedOverrideReference implements Interface
+func (r *sleeper) IsSupportedOverrideReference(ip string) error {
+	return nil
+}
+
 // Build implements Interface
 func (r *sleeper) Build(_ context.Context, ip string) (Result, error) {
 	time.Sleep(50 * time.Millisecond)

--- a/pkg/build/recorder.go
+++ b/pkg/build/recorder.go
@@ -41,6 +41,11 @@ func (r *Recorder) IsSupportedReference(ip string) error {
 	return r.Builder.IsSupportedReference(ip)
 }
 
+// IsSupportedOverrideReference implements build.Interface
+func (r *Recorder) IsSupportedOverrideReference(ip string) error {
+	return r.Builder.IsSupportedOverrideReference(ip)
+}
+
 // Build implements Interface
 func (r *Recorder) Build(ctx context.Context, ip string) (Result, error) {
 	func() {

--- a/pkg/build/shared.go
+++ b/pkg/build/shared.go
@@ -76,6 +76,11 @@ func (c *Caching) IsSupportedReference(ip string) error {
 	return c.inner.IsSupportedReference(ip)
 }
 
+// IsSupportedOverrideReference implements Interface
+func (c *Caching) IsSupportedOverrideReference(ip string) error {
+	return c.inner.IsSupportedOverrideReference(ip)
+}
+
 // Invalidate removes an import path's cached results.
 func (c *Caching) Invalidate(ip string) {
 	c.m.Lock()

--- a/pkg/build/shared_test.go
+++ b/pkg/build/shared_test.go
@@ -35,6 +35,8 @@ func (sb *slowbuild) QualifyImport(ip string) (string, error) { return ip, nil }
 
 func (sb *slowbuild) IsSupportedReference(string) error { return nil }
 
+func (sb *slowbuild) IsSupportedOverrideReference(string) error { return nil }
+
 func (sb *slowbuild) Build(context.Context, string) (Result, error) {
 	time.Sleep(sb.sleep)
 	return random.Index(256, 8, 3)
@@ -49,6 +51,10 @@ func TestCaching(t *testing.T) {
 
 	if err := cb.IsSupportedReference(ip); err != nil {
 		t.Errorf("ISR(%q) = (%v), wanted nil", err, ip)
+	}
+
+	if err := cb.IsSupportedOverrideReference(ip); err != nil {
+		t.Errorf("ISOR(%q) = (%v), wanted nil", err, ip)
 	}
 
 	previousDigest := "not-a-digest"

--- a/pkg/build/strict.go
+++ b/pkg/build/strict.go
@@ -46,3 +46,34 @@ func (r reference) String() string {
 	}
 	return r.Path()
 }
+
+// StrictOverrideScheme is a prefix that can be placed on YAML values
+// that will be converted to static values.
+const StrictOverrideScheme = "koverride://"
+
+type overrideReference struct {
+	strict bool
+	path   string
+}
+
+func newOverrideRef(s string) overrideReference {
+	return overrideReference{
+		strict: strings.HasPrefix(s, StrictOverrideScheme),
+		path:   strings.TrimPrefix(s, StrictOverrideScheme),
+	}
+}
+
+func (r overrideReference) IsStrict() bool {
+	return r.strict
+}
+
+func (r overrideReference) Path() string {
+	return r.path
+}
+
+func (r overrideReference) String() string {
+	if r.IsStrict() {
+		return StrictOverrideScheme + r.Path()
+	}
+	return r.Path()
+}

--- a/pkg/build/strict_test.go
+++ b/pkg/build/strict_test.go
@@ -49,3 +49,37 @@ func TestStrictReference(t *testing.T) {
 		})
 	}
 }
+
+func TestStrictOverrideReference(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		strict bool
+		path   string
+	}{{
+		name:   "loose",
+		input:  "bloop",
+		strict: false,
+		path:   "bloop",
+	}, {
+		name:   "strict",
+		input:  "koverride://blip",
+		strict: true,
+		path:   "blip",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ref := newOverrideRef(test.input)
+			if got, want := ref.IsStrict(), test.strict; got != want {
+				t.Errorf("got: %v, want: %v", got, want)
+			}
+			if got, want := ref.Path(), test.path; got != want {
+				t.Errorf("got: %v, want: %v", got, want)
+			}
+			if got, want := ref.String(), test.input; got != want {
+				t.Errorf("got: %v, want: %v", got, want)
+			}
+		})
+	}
+}

--- a/pkg/commands/options/filestuff.go
+++ b/pkg/commands/options/filestuff.go
@@ -35,15 +35,18 @@ For more information see:
 
 // FilenameOptions is from pkg/kubectl.
 type FilenameOptions struct {
-	Filenames []string
-	Recursive bool
-	Watch     bool
+	Filenames  []string
+	Koverrides string
+	Recursive  bool
+	Watch      bool
 }
 
 func AddFileArg(cmd *cobra.Command, fo *FilenameOptions) {
 	// From pkg/kubectl
 	cmd.Flags().StringSliceVarP(&fo.Filenames, "filename", "f", fo.Filenames,
 		"Filename, directory, or URL to files to use to create the resource")
+	cmd.Flags().StringVar(&fo.Koverrides, "koverrides", fo.Koverrides,
+		"Filename to use for koverrides")
 	cmd.Flags().BoolVarP(&fo.Recursive, "recursive", "R", fo.Recursive,
 		"Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.")
 	cmd.Flags().BoolVarP(&fo.Watch, "watch", "W", fo.Watch,

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -285,6 +285,20 @@ func resolveFilesToWriter(
 	out io.WriteCloser) error {
 	defer out.Close()
 
+	// Attempt to parse koverrides YAML file into context (if provided)
+	if fo.Koverrides != "" {
+		b, err := ioutil.ReadFile(fo.Koverrides)
+		if err != nil {
+			return fmt.Errorf("opening koverrides file: %w", err)
+		}
+		var overrides map[string]interface{}
+		if err := yaml.Unmarshal(b, &overrides); err != nil {
+			return fmt.Errorf("parsing koverrides file: %w", err)
+		}
+		//lint:ignore SA1029 TODO(jdolitsky): use custom type for context
+		ctx = context.WithValue(ctx, build.StrictOverrideScheme, overrides)
+	}
+
 	// By having this as a channel, we can hook this up to a filesystem
 	// watcher and leave `fs` open to stream the names of yaml files
 	// affected by code changes (including the modification of existing or

--- a/pkg/internal/testing/fixed.go
+++ b/pkg/internal/testing/fixed.go
@@ -52,6 +52,14 @@ func (f *fixedBuild) IsSupportedReference(s string) error {
 	return nil
 }
 
+// IsSupportedOverrideReference implements build.Interface
+func (f *fixedBuild) IsSupportedOverrideReference(s string) error {
+	if !strings.HasPrefix(s, build.StrictOverrideScheme) {
+		return errors.New("value does not start with koverride://")
+	}
+	return nil
+}
+
 // Build implements build.Interface
 func (f *fixedBuild) Build(_ context.Context, s string) (build.Result, error) {
 	s = strings.TrimPrefix(s, build.StrictScheme)


### PR DESCRIPTION
Introduce the concept of koverrides, which provide a lightweight interface for supplying environment-specific configuration settings in Kubernetes YAML files(s).

Similar to the `ko://` prefix, YAML nodes containing a `koverride://` prefix will be preprocessed. Users can then use the `--koverrides` flag to provide configuration overrides (if necessary).

See README updates in this changeset for more details. 

*(copy pasting README changes below)*

## "koverrides"

When using `ko` in the context of Kubernetes, you may wish to reuse your YAML file(s)
across several different environments.

As a lightweight solution for environment-specific configuration, you can leverage
"koverrides" (a.k.a. `ko` overrides).

Using koverrides, you can prefix values with `koverride://` and supply a default value:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: demo
data:
  db-host: koverride://db.host/mysql.default.svc
  db-port: koverride://db.port/3306
  db-user: koverride://db.user
  db-pass: koverride://db.pass
```

The default value can be defined as everything after the first forward slash (`/`)
character. If there is no default, then an empty string will be used (`""`).
Nested keys are supported using dot (`.`) notation.

Consider the following koverrides file, `demo.yaml`:

```yaml
db:
  host: db.example.com
  user: secretuser
  pass: secretpass
```

Now we run `ko resolve` (or `ko apply`) using the
`--koverrides` flag, pointing to the file:

```
ko resolve -f config/ --koverrides demo.yaml
```

Which produces the following YAML:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: demo
data:
  db-host: db.example.com
  db-port: "3306"
  db-user: secretuser
  db-pass: secretpass
```

For practical purposes, all resulting values are coerced to strings
(e.g. `3306 -> "3306"`).

This feature is particularly useful for Kubernetes resource types designed
for configuration purposes, such as ConfigMaps or Secrets.


