### PR TITLE
Log base image@digest when building

### DIFF
--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -106,11 +106,16 @@ func getBaseImage(bo *options.BuildOptions) build.GetBase {
 			return ref, cached, nil
 		}
 
-		log.Printf("Using base %s for %s", ref, s)
 		result, err := fetch(ctx, ref)
 		if err != nil {
 			return ref, result, err
 		}
+		dig, err := result.Digest()
+		if err != nil {
+			return ref, result, err
+		}
+		resolved := ref.Context().Digest(dig.String())
+		log.Printf("Using base %s (%s) for %s", ref, resolved, s)
 
 		cache[ref.String()] = result
 		return ref, result, nil

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -118,8 +118,7 @@ func getBaseImage(bo *options.BuildOptions) build.GetBase {
 			if err != nil {
 				return ref, result, err
 			}
-			resolved := ref.Context().Digest(dig.String())
-			log.Printf("Using base %s (%s) for %s", ref, resolved, s)
+			log.Printf("Using base %s@%s for %s", ref, dig, s)
 		}
 
 		cache[ref.String()] = result

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -110,12 +110,17 @@ func getBaseImage(bo *options.BuildOptions) build.GetBase {
 		if err != nil {
 			return ref, result, err
 		}
-		dig, err := result.Digest()
-		if err != nil {
-			return ref, result, err
+
+		if _, ok := ref.(name.Digest); ok {
+			log.Printf("Using base %s for %s", ref, s)
+		} else {
+			dig, err := result.Digest()
+			if err != nil {
+				return ref, result, err
+			}
+			resolved := ref.Context().Digest(dig.String())
+			log.Printf("Using base %s (%s) for %s", ref, resolved, s)
 		}
-		resolved := ref.Context().Digest(dig.String())
-		log.Printf("Using base %s (%s) for %s", ref, resolved, s)
 
 		cache[ref.String()] = result
 		return ref, result, nil


### PR DESCRIPTION
Before:

```
2022/02/11 09:15:05 Using base golang:1.17 for github.com/google/ko
```

After:

```
2022/02/11 09:13:49 Using base golang:1.17 (index.docker.io/library/golang@sha256:1a35cc2c5338409227c7293add327ebe42e1ee5465049f6c57c829588e3f8a39) for github.com/google/ko
```

I couldn't tell where else to find the specific base image that was used before, without trying to guess using layer digests.