### PR TITLE
Introduce --verbose flag that enables logs.Warn logs

### DIFF
--- a/cmd/ko/main.go
+++ b/cmd/ko/main.go
@@ -20,9 +20,7 @@ package main
 
 import (
 	"log"
-	"os"
 
-	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/ko/pkg/commands"
 )
 
@@ -36,9 +34,6 @@ For more information see:
 `
 
 func main() {
-	logs.Warn.SetOutput(os.Stderr)
-	logs.Progress.SetOutput(os.Stderr)
-
 	log.Print(Deprecation258)
 
 	if err := commands.Root.Execute(); err != nil {

--- a/doc/ko.md
+++ b/doc/ko.md
@@ -9,7 +9,8 @@ ko [flags]
 ### Options
 
 ```
-  -h, --help   help for ko
+  -h, --help      help for ko
+  -v, --verbose   Enable debug logs
 ```
 
 ### SEE ALSO

--- a/doc/ko_apply.md
+++ b/doc/ko_apply.md
@@ -86,6 +86,12 @@ ko apply -f FILENAME [flags]
   -W, --watch                          Continuously monitor the transitive dependencies of the passed yaml files, and redeploy whenever anything changes. (DEPRECATED)
 ```
 
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable debug logs
+```
+
 ### SEE ALSO
 
 * [ko](ko.md)	 - Rapidly iterate with Go, Containers, and Kubernetes.

--- a/doc/ko_build.md
+++ b/doc/ko_build.md
@@ -62,6 +62,12 @@ ko build IMPORTPATH... [flags]
       --tarball string           File to save images tarballs
 ```
 
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable debug logs
+```
+
 ### SEE ALSO
 
 * [ko](ko.md)	 - Rapidly iterate with Go, Containers, and Kubernetes.

--- a/doc/ko_create.md
+++ b/doc/ko_create.md
@@ -86,6 +86,12 @@ ko create -f FILENAME [flags]
   -W, --watch                          Continuously monitor the transitive dependencies of the passed yaml files, and redeploy whenever anything changes. (DEPRECATED)
 ```
 
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable debug logs
+```
+
 ### SEE ALSO
 
 * [ko](ko.md)	 - Rapidly iterate with Go, Containers, and Kubernetes.

--- a/doc/ko_delete.md
+++ b/doc/ko_delete.md
@@ -12,6 +12,12 @@ ko delete [flags]
   -h, --help   help for delete
 ```
 
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable debug logs
+```
+
 ### SEE ALSO
 
 * [ko](ko.md)	 - Rapidly iterate with Go, Containers, and Kubernetes.

--- a/doc/ko_deps.md
+++ b/doc/ko_deps.md
@@ -27,6 +27,12 @@ ko deps IMAGE [flags]
       --sbom string   Format for SBOM output (supports: spdx, go.version-m). (default "spdx")
 ```
 
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable debug logs
+```
+
 ### SEE ALSO
 
 * [ko](ko.md)	 - Rapidly iterate with Go, Containers, and Kubernetes.

--- a/doc/ko_login.md
+++ b/doc/ko_login.md
@@ -22,6 +22,12 @@ ko login [OPTIONS] [SERVER] [flags]
   -u, --username string   Username
 ```
 
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable debug logs
+```
+
 ### SEE ALSO
 
 * [ko](ko.md)	 - Rapidly iterate with Go, Containers, and Kubernetes.

--- a/doc/ko_resolve.md
+++ b/doc/ko_resolve.md
@@ -61,6 +61,12 @@ ko resolve -f FILENAME [flags]
   -W, --watch                    Continuously monitor the transitive dependencies of the passed yaml files, and redeploy whenever anything changes. (DEPRECATED)
 ```
 
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable debug logs
+```
+
 ### SEE ALSO
 
 * [ko](ko.md)	 - Rapidly iterate with Go, Containers, and Kubernetes.

--- a/doc/ko_run.md
+++ b/doc/ko_run.md
@@ -49,6 +49,12 @@ ko run IMPORTPATH [flags]
       --tarball string           File to save images tarballs
 ```
 
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable debug logs
+```
+
 ### SEE ALSO
 
 * [ko](ko.md)	 - Rapidly iterate with Go, Containers, and Kubernetes.

--- a/doc/ko_version.md
+++ b/doc/ko_version.md
@@ -12,6 +12,12 @@ ko version [flags]
   -h, --help   help for version
 ```
 
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable debug logs
+```
+
 ### SEE ALSO
 
 * [ko](ko.md)	 - Rapidly iterate with Go, Containers, and Kubernetes.

--- a/main.go
+++ b/main.go
@@ -22,14 +22,10 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/ko/pkg/commands"
 )
 
 func main() {
-	logs.Warn.SetOutput(os.Stderr)
-	logs.Progress.SetOutput(os.Stderr)
-
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 	if err := commands.Root.ExecuteContext(ctx); err != nil {

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -15,22 +15,35 @@
 package commands
 
 import (
+	"os"
+
 	cranecmd "github.com/google/go-containerregistry/cmd/crane/cmd"
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/spf13/cobra"
 )
 
 var Root = New()
 
 func New() *cobra.Command {
+	var verbose bool
 	root := &cobra.Command{
 		Use:               "ko",
 		Short:             "Rapidly iterate with Go, Containers, and Kubernetes.",
 		SilenceUsage:      true, // Don't show usage on errors
 		DisableAutoGenTag: true,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if verbose {
+				logs.Warn.SetOutput(os.Stderr)
+				logs.Debug.SetOutput(os.Stderr)
+			}
+			logs.Progress.SetOutput(os.Stderr)
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Help()
 		},
 	}
+	root.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable debug logs")
+
 	AddKubeCommands(root)
 
 	// Also add the auth group from crane to facilitate logging into a


### PR DESCRIPTION
This eliminates `pkg/v1/google.Keychain` log spam when gcloud is not installed and correctly configured.

This also hides `No matching credentials for ...` lines (from [here](https://github.com/google/go-containerregistry/blob/a0c4bd256482b8522065d5f6cf966281ef270680/pkg/v1/remote/transport/bearer.go#L268)) and HTTP retry logging (from [here](https://github.com/google/go-containerregistry/blob/a83d6e97daf45eebbe54d668e9a3c51d6b811d39/pkg/v1/remote/options.go#L63)).