### PR TITLE
update go 1.18 buildinfo

### DIFF
--- a/internal/sbom/mod_1.18.go
+++ b/internal/sbom/mod_1.18.go
@@ -24,10 +24,10 @@ import (
 type BuildInfo debug.BuildInfo
 
 func (bi *BuildInfo) UnmarshalText(data []byte) error {
-	dbi := (*debug.BuildInfo)(bi)
-	if err := dbi.UnmarshalText(data); err != nil {
+	dbi, err := debug.ParseBuildInfo(string(data))
+	if err != nil {
 		return err
 	}
-	bi = (*BuildInfo)(dbi)
+	*bi = BuildInfo(*dbi)
 	return nil
 }


### PR DESCRIPTION
golang/go#51026 changed `buildinfo.UnmarshalText` to `ParseBuildInfo`