### PR TITLE
warning users when using both --base-import-paths --bare flags

### DIFF
--- a/pkg/commands/apply.go
+++ b/pkg/commands/apply.go
@@ -82,6 +82,10 @@ func addApply(topLevel *cobra.Command) {
   ko apply -f config -- --namespace=foo --kubeconfig=cfg.yaml
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := options.Validate(po, bo); err != nil {
+				return fmt.Errorf("validating options: %w", err)
+			}
+
 			if !isKubectlAvailable() {
 				return errors.New("error: kubectl is not available. kubectl must be installed to use ko apply")
 			}

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -58,6 +58,10 @@ func addBuild(topLevel *cobra.Command) {
   ko build --local github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := options.Validate(po, bo); err != nil {
+				return fmt.Errorf("validating options: %w", err)
+			}
+
 			ctx := cmd.Context()
 
 			bo.InsecureRegistry = po.InsecureRegistry

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -67,6 +67,10 @@ func addCreate(topLevel *cobra.Command) {
   ko apply -f config -- --namespace=foo --kubeconfig=cfg.yaml
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := options.Validate(po, bo); err != nil {
+				return fmt.Errorf("validating options: %w", err)
+			}
+
 			if !isKubectlAvailable() {
 				return errors.New("error: kubectl is not available. kubectl must be installed to use ko create")
 			}

--- a/pkg/commands/options/validate.go
+++ b/pkg/commands/options/validate.go
@@ -1,18 +1,16 @@
-/*
-Copyright 2022 Google LLC All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2022 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package options
 

--- a/pkg/commands/options/validate.go
+++ b/pkg/commands/options/validate.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2022 Google LLC All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import "log"
+
+const bareBaseFlagsWarning = `WARNING!
+-----------------------------------------------------------------
+Both --base-import-paths and --bare were set.
+
+--base-import-paths will take precedence and ignore --bare flag.
+
+In a future release this will be an error.
+-----------------------------------------------------------------
+`
+
+func Validate(po *PublishOptions, bo *BuildOptions) error {
+	if po.Bare && po.BaseImportPaths {
+		log.Print(bareBaseFlagsWarning)
+		// TODO: return error when we decided to make this an error, for now it is a warning
+	}
+
+	return nil
+}

--- a/pkg/commands/resolve.go
+++ b/pkg/commands/resolve.go
@@ -55,6 +55,10 @@ func addResolve(topLevel *cobra.Command) {
   ko resolve --local -f config/`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := options.Validate(po, bo); err != nil {
+				return fmt.Errorf("validating options: %w", err)
+			}
+
 			ctx := cmd.Context()
 
 			bo.InsecureRegistry = po.InsecureRegistry

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -49,6 +49,10 @@ func addRun(topLevel *cobra.Command) {
   # You can also supply args and flags to the command.
   ko run ./cmd/baz -- -v arg1 arg2 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := options.Validate(po, bo); err != nil {
+				return fmt.Errorf("validating options: %w", err)
+			}
+
 			ctx := cmd.Context()
 
 			// Args after -- are for kubectl, so only consider importPaths before it.


### PR DESCRIPTION
warning users when using both --base-import-paths --bare flags

Partially fixes #542 

@imjasonh let me know if this is something you have in mind, otherwise, if this is not the project want we can close or improve. thanks!

```
$ ./main build --base-import-paths  --bare .
2022/02/25 17:55:08 WARNING!
-----------------------------------------------------------------
Both --base-import-paths and --bare was set.

--base-import-paths will take precedence and ignore --bare flag.

In future this will be an error
-----------------------------------------------------------------
2022/02/25 17:55:10 Using base golang:1.17@sha256:e06c83493ef6d69c95018da90f2887bf337470db074d3c648b8b648d8e3c441e for github.com/google/ko
2022/02/25 17:55:10 Building github.com/google/ko for linux/amd64
^C2022/02/25 17:55:11 Unexpected error running "go build": signal: killed
Error: failed to publish images: error building "ko://github.com/google/ko": signal: killed
2022/02/25 17:55:11 error during command execution:failed to publish images: error building "ko://github.com/google/ko": signal: killed
```