### PR TITLE
check if have all and other platforms set in the --platform flag

### DIFF
--- a/pkg/commands/options/validate.go
+++ b/pkg/commands/options/validate.go
@@ -40,14 +40,6 @@ The --local flag might be deprecated in the future.
 -----------------------------------------------------------------
 `
 
-const platformsFlagWarning = `ERROR!
------------------------------------------------------------------------
-The --platform was set with all and other specific platforms.
-
-Please choose either all or a specific one, ie. --platform=linux/arm64
------------------------------------------------------------------------
-`
-
 func Validate(po *PublishOptions, bo *BuildOptions) error {
 	if po.Bare && po.BaseImportPaths {
 		log.Print(bareBaseFlagsWarning)
@@ -59,17 +51,10 @@ func Validate(po *PublishOptions, bo *BuildOptions) error {
 	}
 
 	if len(bo.Platforms) > 1 {
-		hasAll := false
-
 		for _, platform := range bo.Platforms {
 			if platform == "all" {
-				hasAll = true
+				return errors.New("all or specific platforms should be used")
 			}
-		}
-
-		if hasAll {
-			log.Print(platformsFlagWarning)
-			return errors.New("all or specific platforms should be used")
 		}
 	}
 

--- a/pkg/commands/options/validate.go
+++ b/pkg/commands/options/validate.go
@@ -15,6 +15,7 @@
 package options
 
 import (
+	"errors"
 	"log"
 	"strings"
 )
@@ -39,6 +40,14 @@ The --local flag might be deprecated in the future.
 -----------------------------------------------------------------
 `
 
+const platformsFlagWarning = `ERROR!
+-----------------------------------------------------------------------
+The --platform was set with all and other specific platforms.
+
+Please choose either all or a specific one, ie. --platform=linux/arm64
+-----------------------------------------------------------------------
+`
+
 func Validate(po *PublishOptions, bo *BuildOptions) error {
 	if po.Bare && po.BaseImportPaths {
 		log.Print(bareBaseFlagsWarning)
@@ -47,6 +56,21 @@ func Validate(po *PublishOptions, bo *BuildOptions) error {
 
 	if po.Local && strings.Contains(po.DockerRepo, "ko.local") {
 		log.Print(localFlagsWarning)
+	}
+
+	if len(bo.Platforms) > 1 {
+		hasAll := false
+
+		for _, platform := range bo.Platforms {
+			if platform == "all" {
+				hasAll = true
+			}
+		}
+
+		if hasAll {
+			log.Print(platformsFlagWarning)
+			return errors.New("all or specific platforms should be used")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
- check if have all and other platforms set in the --platform flag

```
../../google/ko/main build --base-import-paths \
--platform=all,linux/arm --tags v1.5.1-96-gd1a4d08-dirty --tags d1a4d086309e22cc85c0c59ac662606a58c81438 github.com/sigstore/cosign/cmd/cosign
Error: validating options: all or specific platforms should be used
2022/03/02 14:12:16 error during command execution:validating options: all or specific platforms should be used
make: *** [ko] Error 1
```

Address https://github.com/google/ko/issues/542#issuecomment-997014021

/cc @imjasonh 