### PR TITLE
Update Go 1.18 code to match RC 1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,12 +23,12 @@ jobs:
           go-version: '1.17.x'
 
       # Use the installed Go version to download and install the latest 1.18
-      # beta and replace our existing go with that one.
+      # release candidate and replace our existing go with that one.
       - if: ${{ matrix.go-version == '1.18.x' }}
         run: |
-          go install golang.org/dl/go1.18beta1@latest
-          go1.18beta1 download
-          cp $(which go1.18beta1) $(which go)
+          go install golang.org/dl/go1.18rc1@latest
+          go1.18rc1 download
+          cp $(which go1.18rc1) $(which go)
           go version
 
       - run: |

--- a/internal/sbom/mod_1.18.go
+++ b/internal/sbom/mod_1.18.go
@@ -18,16 +18,17 @@
 package sbom
 
 import (
+	"fmt"
 	"runtime/debug"
 )
 
 type BuildInfo debug.BuildInfo
 
 func (bi *BuildInfo) UnmarshalText(data []byte) error {
-	dbi := (*debug.BuildInfo)(bi)
-	if err := dbi.UnmarshalText(data); err != nil {
-		return err
+	dbi, err := debug.ParseBuildInfo(string(data))
+	if err != nil {
+		return fmt.Errorf("parsing build info: %w", err)
 	}
-	bi = (*BuildInfo)(dbi)
+	*bi = BuildInfo(*dbi)
 	return nil
 }


### PR DESCRIPTION
Also update CI to use the latest RC -- `beta1` and `beta2` worked with the previous code, `rc1` is the only release (so far) that uses the new code.

Closes #610
Fixes #625