### PR TITLE
Correctly pass through base image annotations

### DIFF
--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -449,7 +449,7 @@ func TestGoBuildNoKoData(t *testing.T) {
 
 	img, ok := result.(v1.Image)
 	if !ok {
-		t.Fatalf("Build() not an image: %v", result)
+		t.Fatalf("Build() not an Image: %T", result)
 	}
 
 	ls, err := img.Layers()
@@ -742,7 +742,7 @@ func TestGoBuild(t *testing.T) {
 
 	img, ok := result.(oci.SignedImage)
 	if !ok {
-		t.Fatalf("Build() not an image: %v", result)
+		t.Fatalf("Build() not a SignedImage: %T", result)
 	}
 
 	validateImage(t, img, baseLayers, creationTime, true, true)
@@ -854,7 +854,7 @@ func TestGoBuildWithoutSBOM(t *testing.T) {
 
 	img, ok := result.(oci.SignedImage)
 	if !ok {
-		t.Fatalf("Build() not an image: %v", result)
+		t.Fatalf("Build() not a SignedImage: %T", result)
 	}
 
 	validateImage(t, img, baseLayers, creationTime, true, false)
@@ -890,7 +890,7 @@ func TestGoBuildIndex(t *testing.T) {
 
 	idx, ok := result.(oci.SignedImageIndex)
 	if !ok {
-		t.Fatalf("Build() not an image: %v", result)
+		t.Fatalf("Build() not a SignedImageIndex: %T", result)
 	}
 
 	im, err := idx.IndexManifest()


### PR DESCRIPTION
There were some bugs here before:

- for indexes, we'd annotate the base, but then append to empty.Index
  which didn't carry those forward.
- when producing single-platform images based on multi-platform indexes
  (the default and most common scenario), we wouldn't carry forward the
  original base index's annotations to the single matching platform base
  image.