### PR TITLE
Include builds for Go 1.18 in CI matrixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,18 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
-          # TODO: when 1.18 is released, just make this
-          # ${{ matrix.go-version }} and delete the next step.
-          go-version: '1.17.x'
-
-      # Use the installed Go version to download and install the latest 1.18
-      # release candidate and replace our existing go with that one.
-      - if: ${{ matrix.go-version == '1.18.x' }}
-        run: |
-          go install golang.org/dl/go1.18rc1@latest
-          go1.18rc1 download
-          cp $(which go1.18rc1) $(which go)
-          go version
+          go-version: ${{ matrix.go-version }}
 
       - run: |
           go build ./...

--- a/.github/workflows/modules-integration-test.yaml
+++ b/.github/workflows/modules-integration-test.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Module Tests
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.16.x, 1.17.x, 1.18.x]
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/setup-go@v2


### PR DESCRIPTION
I'm keeping Go 1.17.x as the main Go version we use in CI for now, to start slow.