### PR TITLE
Revert "Produce OCI images by default (#623)"

### DIFF
--- a/doc/ko_apply.md
+++ b/doc/ko_apply.md
@@ -70,7 +70,6 @@ ko apply -f FILENAME [flags]
       --password string                Password for basic authentication to the API server (DEPRECATED)
       --platform strings               Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths          Whether to preserve the full import path after KO_DOCKER_REPO.
-      --preserve-media-type            If false, push images in OCI format regardless of base image format
       --push                           Push images to KO_DOCKER_REPO (default true)
   -R, --recursive                      Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (DEPRECATED)

--- a/doc/ko_build.md
+++ b/doc/ko_build.md
@@ -55,7 +55,6 @@ ko build IMPORTPATH... [flags]
       --oci-layout-path string   Path to save the OCI image layout of the built images
       --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --preserve-media-type      If false, push images in OCI format regardless of base image format
       --push                     Push images to KO_DOCKER_REPO (default true)
       --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m). (default "spdx")
       --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.

--- a/doc/ko_create.md
+++ b/doc/ko_create.md
@@ -70,7 +70,6 @@ ko create -f FILENAME [flags]
       --password string                Password for basic authentication to the API server (DEPRECATED)
       --platform strings               Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths          Whether to preserve the full import path after KO_DOCKER_REPO.
-      --preserve-media-type            If false, push images in OCI format regardless of base image format
       --push                           Push images to KO_DOCKER_REPO (default true)
   -R, --recursive                      Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (DEPRECATED)

--- a/doc/ko_resolve.md
+++ b/doc/ko_resolve.md
@@ -51,7 +51,6 @@ ko resolve -f FILENAME [flags]
       --oci-layout-path string   Path to save the OCI image layout of the built images
       --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --preserve-media-type      If false, push images in OCI format regardless of base image format
       --push                     Push images to KO_DOCKER_REPO (default true)
   -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
       --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m). (default "spdx")

--- a/doc/ko_run.md
+++ b/doc/ko_run.md
@@ -42,7 +42,6 @@ ko run IMPORTPATH [flags]
       --oci-layout-path string   Path to save the OCI image layout of the built images
       --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --preserve-media-type      If false, push images in OCI format regardless of base image format
       --push                     Push images to KO_DOCKER_REPO (default true)
       --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m). (default "spdx")
       --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -73,16 +73,6 @@ func WithTrimpath(v bool) Option {
 	}
 }
 
-// WithPreserveMediaType is a functional option that controls whether to
-// preserve media types from base images. If false, images that are produced
-// will use OCI media types instead.
-func WithPreserveMediaType(v bool) Option {
-	return func(gbo *gobuildOpener) error {
-		gbo.preserveMediaType = v
-		return nil
-	}
-}
-
 // WithConfig is a functional option for providing GoReleaser Build influenced
 // build settings for importpaths.
 //

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -67,9 +67,6 @@ type BuildOptions struct {
 
 	// BuildConfigs stores the per-image build config from `.ko.yaml`.
 	BuildConfigs map[string]build.Config
-
-	// If true, don't convert Docker-typed base images to OCI when building.
-	PreserveMediaType bool
 }
 
 func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
@@ -83,9 +80,6 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*")
 	cmd.Flags().StringSliceVar(&bo.Labels, "image-label", []string{},
 		"Which labels (key=value) to add to the image.")
-
-	cmd.Flags().BoolVar(&bo.PreserveMediaType, "preserve-media-type", false, "If false, push images in OCI format regardless of base image format")
-
 	bo.Trimpath = true
 }
 

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -108,7 +108,6 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 		opts = append(opts, build.WithSPDX(version()))
 	}
 	opts = append(opts, build.WithTrimpath(bo.Trimpath))
-	opts = append(opts, build.WithPreserveMediaType(bo.PreserveMediaType))
 	for _, lf := range bo.Labels {
 		parts := strings.SplitN(lf, "=", 2)
 		if len(parts) != 2 {


### PR DESCRIPTION
This reverts commit 7e9709a63a6bedc92020d0c4335e81a07b10e0d2

This change causes breakages when pushing to Quay.io, the fix for which (#641) causes mysterious errors in KinD.

Until we understand the compatibility story better, let's revert and unblock a v0.11 release to better support Go 1.18.