### PR TITLE
Add purls to SPDX sbom

### DIFF
--- a/internal/sbom/cyclonedx.go
+++ b/internal/sbom/cyclonedx.go
@@ -21,10 +21,32 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 func bomRef(path, version string) string {
 	return fmt.Sprintf("pkg:golang/%s@%s?type=module", path, version)
+}
+
+func goRef(path, version string) string {
+	// Try to lowercase the first 2 path elements to comply with spec
+	// https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#golang
+	p := strings.Split(path, "/")
+	if len(p) > 2 {
+		path = strings.Join(
+			append(
+				[]string{strings.ToLower(p[0]), strings.ToLower(p[1])},
+				p[2:(len(p)-1)]...,
+			), "/",
+		)
+	}
+	return fmt.Sprintf("pkg:golang/%s@%s?type=module", path, version)
+}
+
+func ociRef(path string, imgDigest v1.Hash) string {
+	parts := strings.Split(path, "/")
+	return fmt.Sprintf("pkg:oci/%s@%s", parts[len(parts)-1], imgDigest.String())
 }
 
 func h1ToSHA256(s string) string {

--- a/internal/sbom/spdx.go
+++ b/internal/sbom/spdx.go
@@ -56,7 +56,8 @@ type tmplInfo struct {
 
 // TODO: use k8s.io/release/pkg/bom
 var tmpl = template.Must(template.New("").Funcs(template.FuncMap{
-	"dots": func(s string) string { return strings.ReplaceAll(s, "/", ".") },
+	"dots":   func(s string) string { return strings.ReplaceAll(s, "/", ".") },
+	"bomRef": func(p, v string) string { return bomRef(p, v) },
 	"h1toSHA256": func(s string) (string, error) {
 		if !strings.HasPrefix(s, "h1:") {
 			return "", fmt.Errorf("malformed sum prefix: %q", s)
@@ -108,6 +109,7 @@ PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
 PackageLicenseComments: NOASSERTION
 PackageComment: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl {{ bomRef .Path .Version }}
 
 {{ end }}
 `))

--- a/internal/sbom/spdx.go
+++ b/internal/sbom/spdx.go
@@ -22,11 +22,13 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 const dateFormat = "2006-01-02T15:04:05Z"
 
-func GenerateSPDX(koVersion string, date time.Time, mod []byte) ([]byte, error) {
+func GenerateSPDX(koVersion string, date time.Time, mod []byte, imgDigest v1.Hash) ([]byte, error) {
 	var err error
 	mod, err = massageGoVersionM(mod)
 	if err != nil {
@@ -43,6 +45,7 @@ func GenerateSPDX(koVersion string, date time.Time, mod []byte) ([]byte, error) 
 		BuildInfo: *bi,
 		Date:      date.Format(dateFormat),
 		KoVersion: koVersion,
+		ImgDigest: imgDigest,
 	}); err != nil {
 		return nil, err
 	}
@@ -52,12 +55,14 @@ func GenerateSPDX(koVersion string, date time.Time, mod []byte) ([]byte, error) 
 type tmplInfo struct {
 	BuildInfo
 	Date, UUID, KoVersion string
+	ImgDigest             v1.Hash
 }
 
 // TODO: use k8s.io/release/pkg/bom
 var tmpl = template.Must(template.New("").Funcs(template.FuncMap{
 	"dots":   func(s string) string { return strings.ReplaceAll(s, "/", ".") },
-	"bomRef": func(p, v string) string { return bomRef(p, v) },
+	"goRef":  func(p, v string) string { return goRef(p, v) },
+	"ociRef": func(p string, d v1.Hash) string { return ociRef(p, d) },
 	"h1toSHA256": func(s string) (string, error) {
 		if !strings.HasPrefix(s, "h1:") {
 			return "", fmt.Errorf("malformed sum prefix: %q", s)
@@ -89,6 +94,7 @@ PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
 PackageLicenseComments: NOASSERTION
 PackageComment: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl {{ ociRef .Path .ImgDigest }}
 
 Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-{{ .BuildInfo.Main.Path | dots }}
 
@@ -109,7 +115,7 @@ PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
 PackageLicenseComments: NOASSERTION
 PackageComment: NOASSERTION
-ExternalRef: PACKAGE-MANAGER purl {{ bomRef .Path .Version }}
+ExternalRef: PACKAGE-MANAGER purl {{ goRef .Path .Version }}
 
 {{ end }}
 `))

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -325,8 +325,11 @@ func spdx(version string) sbomber {
 		if err != nil {
 			return nil, "", err
 		}
-
-		b, err = sbom.GenerateSPDX(version, cfg.Created.Time, b)
+		imgDigest, err := img.Digest()
+		if err != nil {
+			return nil, "", err
+		}
+		b, err = sbom.GenerateSPDX(version, cfg.Created.Time, b, imgDigest)
 		if err != nil {
 			return nil, "", err
 		}

--- a/pkg/commands/deps.go
+++ b/pkg/commands/deps.go
@@ -132,9 +132,13 @@ If the image was not built using ko, or if it was built without embedding depend
 					[]byte(n),
 					[]byte(path.Join("/ko-app", filepath.Base(filepath.Clean(h.Name)))),
 					1)
+				imgDigest, err := img.Digest()
+				if err != nil {
+					return err
+				}
 				switch sbomType {
 				case "spdx":
-					b, err := sbom.GenerateSPDX(Version, cfg.Created.Time, mod)
+					b, err := sbom.GenerateSPDX(Version, cfg.Created.Time, mod, imgDigest)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
This PR modifies the SPDX sbom output to include purls that add context for external tools to better infer the types of packages described in the document. 

**Note:**
As each sbom is describing the dependencies of the image it is attached to, the purl type is set to `:oci`. 
This introduces a divergence with the way the CycloneDX sbom expresses its components as the top component is a reference to golang source and not to the image. I think we should change this to express the sboms describe the images, not a go package.

/cc @imjasonh @mattmoor 