### PR TITLE
Fix texts regarding SBOM

### DIFF
--- a/doc/ko_apply.md
+++ b/doc/ko_apply.md
@@ -73,7 +73,7 @@ ko apply -f FILENAME [flags]
       --push                           Push images to KO_DOCKER_REPO (default true)
   -R, --recursive                      Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (DEPRECATED)
-      --sbom string                    The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m). (default "spdx")
+      --sbom string                    The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
   -l, --selector string                Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
   -s, --server string                  The address and port of the Kubernetes API server (DEPRECATED)
       --tag-only                       Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.

--- a/doc/ko_build.md
+++ b/doc/ko_build.md
@@ -56,7 +56,7 @@ ko build IMPORTPATH... [flags]
       --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
       --push                     Push images to KO_DOCKER_REPO (default true)
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m). (default "spdx")
+      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
       --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
       --tarball string           File to save images tarballs

--- a/doc/ko_create.md
+++ b/doc/ko_create.md
@@ -73,7 +73,7 @@ ko create -f FILENAME [flags]
       --push                           Push images to KO_DOCKER_REPO (default true)
   -R, --recursive                      Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (DEPRECATED)
-      --sbom string                    The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m). (default "spdx")
+      --sbom string                    The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
   -l, --selector string                Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
   -s, --server string                  The address and port of the Kubernetes API server (DEPRECATED)
       --tag-only                       Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.

--- a/doc/ko_deps.md
+++ b/doc/ko_deps.md
@@ -24,7 +24,7 @@ ko deps IMAGE [flags]
 
 ```
   -h, --help          help for deps
-      --sbom string   Format for SBOM output (supports: spdx, go.version-m). (default "spdx")
+      --sbom string   Format for SBOM output (supports: spdx, cyclonedx, go.version-m). (default "spdx")
 ```
 
 ### Options inherited from parent commands

--- a/doc/ko_resolve.md
+++ b/doc/ko_resolve.md
@@ -53,7 +53,7 @@ ko resolve -f FILENAME [flags]
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
       --push                     Push images to KO_DOCKER_REPO (default true)
   -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m). (default "spdx")
+      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
   -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
       --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])

--- a/doc/ko_run.md
+++ b/doc/ko_run.md
@@ -43,7 +43,7 @@ ko run IMPORTPATH [flags]
       --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
       --push                     Push images to KO_DOCKER_REPO (default true)
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m). (default "spdx")
+      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
       --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
       --tarball string           File to save images tarballs

--- a/pkg/commands/deps.go
+++ b/pkg/commands/deps.go
@@ -52,7 +52,7 @@ If the image was not built using ko, or if it was built without embedding depend
 			switch sbomType {
 			case "cyclonedx", "spdx", "go.version-m":
 			default:
-				return fmt.Errorf("invalid sbom type %q: must be spdx or go.version-m", sbomType)
+				return fmt.Errorf("invalid sbom type %q: must be spdx, cyclonedx or go.version-m", sbomType)
 			}
 
 			ref, err := name.ParseReference(args[0])
@@ -157,6 +157,6 @@ If the image was not built using ko, or if it was built without embedding depend
 			// unreachable
 		},
 	}
-	deps.Flags().StringVar(&sbomType, "sbom", "spdx", "Format for SBOM output (supports: spdx, go.version-m).")
+	deps.Flags().StringVar(&sbomType, "sbom", "spdx", "Format for SBOM output (supports: spdx, cyclonedx, go.version-m).")
 	topLevel.AddCommand(deps)
 }

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -75,7 +75,7 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 	cmd.Flags().BoolVar(&bo.DisableOptimizations, "disable-optimizations", bo.DisableOptimizations,
 		"Disable optimizations when building Go code. Useful when you want to interactively debug the created container.")
 	cmd.Flags().StringVar(&bo.SBOM, "sbom", "spdx",
-		"The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, go.version-m).")
+		"The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m).")
 	cmd.Flags().StringSliceVar(&bo.Platforms, "platform", []string{},
 		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*")
 	cmd.Flags().StringSliceVar(&bo.Labels, "image-label", []string{},


### PR DESCRIPTION
Thank you for the great project. I am learning about SBOM and found that help texts and the error message seem to be incorrect.
`ko` can generate cyclonedx format, but help texts and the error message does not include cyclonedx.

I fixed help texts and the error message and ran `./hack/update-codegen.sh`.