### PR TITLE
build: Imply current import path

### DIFF
--- a/doc/ko_build.md
+++ b/doc/ko_build.md
@@ -14,27 +14,26 @@ ko build IMPORTPATH... [flags]
 
 ```
 
-  # Build and publish import path references to a Docker
-  # Registry as:
+  # Build and publish import path references to a Docker Registry as:
   #   ${KO_DOCKER_REPO}/<package name>-<hash of import path>
-  # When KO_DOCKER_REPO is ko.local, it is the same as if
-  # --local and --preserve-import-paths were passed.
+  # When KO_DOCKER_REPO is ko.local, it is the same as if --local and
+  # --preserve-import-paths were passed.
+  # If the import path is not provided, the current working directory is the
+  # default.
   ko build github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah
 
   # Build and publish a relative import path as:
   #   ${KO_DOCKER_REPO}/<package name>-<hash of import path>
-  # When KO_DOCKER_REPO is ko.local, it is the same as if
-  # --local and --preserve-import-paths were passed.
+  # When KO_DOCKER_REPO is ko.local, it is the same as if --local and
+  # --preserve-import-paths were passed.
   ko build ./cmd/blah
 
   # Build and publish a relative import path as:
   #   ${KO_DOCKER_REPO}/<import path>
-  # When KO_DOCKER_REPO is ko.local, it is the same as if
-  # --local was passed.
+  # When KO_DOCKER_REPO is ko.local, it is the same as if --local was passed.
   ko build --preserve-import-paths ./cmd/blah
 
-  # Build and publish import path references to a Docker
-  # daemon as:
+  # Build and publish import path references to a Docker daemon as:
   #   ko.local/<import path>
   # This always preserves import paths.
   ko build --local github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -32,34 +32,37 @@ func addBuild(topLevel *cobra.Command) {
 		Long:    `This sub-command builds the provided import paths into Go binaries, containerizes them, and publishes them.`,
 		Aliases: []string{"publish"},
 		Example: `
-  # Build and publish import path references to a Docker
-  # Registry as:
+  # Build and publish import path references to a Docker Registry as:
   #   ${KO_DOCKER_REPO}/<package name>-<hash of import path>
-  # When KO_DOCKER_REPO is ko.local, it is the same as if
-  # --local and --preserve-import-paths were passed.
+  # When KO_DOCKER_REPO is ko.local, it is the same as if --local and
+  # --preserve-import-paths were passed.
+  # If the import path is not provided, the current working directory is the
+  # default.
   ko build github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah
 
   # Build and publish a relative import path as:
   #   ${KO_DOCKER_REPO}/<package name>-<hash of import path>
-  # When KO_DOCKER_REPO is ko.local, it is the same as if
-  # --local and --preserve-import-paths were passed.
+  # When KO_DOCKER_REPO is ko.local, it is the same as if --local and
+  # --preserve-import-paths were passed.
   ko build ./cmd/blah
 
   # Build and publish a relative import path as:
   #   ${KO_DOCKER_REPO}/<import path>
-  # When KO_DOCKER_REPO is ko.local, it is the same as if
-  # --local was passed.
+  # When KO_DOCKER_REPO is ko.local, it is the same as if --local was passed.
   ko build --preserve-import-paths ./cmd/blah
 
-  # Build and publish import path references to a Docker
-  # daemon as:
+  # Build and publish import path references to a Docker daemon as:
   #   ko.local/<import path>
   # This always preserves import paths.
   ko build --local github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah`,
-		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := options.Validate(po, bo); err != nil {
 				return fmt.Errorf("validating options: %w", err)
+			}
+
+			if len(args) == 0 {
+				// Build the current directory by default.
+				args = []string{"."}
 			}
 
 			ctx := cmd.Context()


### PR DESCRIPTION
This changes `ko build` to not require any positional arg, and instead assume the positional arg `.` if none is passed.

This means that `ko build` can be invoked exactly, without any args, and has the same effect as `ko build .` or `ko build ./`.

This matches the behavior of `go build`.