### PR TITLE
allow refs-file to be read by other users

### DIFF
--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -237,7 +237,7 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 	}
 
 	if po.ImageRefsFile != "" {
-		f, err := os.OpenFile(po.ImageRefsFile, os.O_RDWR|os.O_CREATE, 0600)
+		f, err := os.OpenFile(po.ImageRefsFile, os.O_RDWR|os.O_CREATE, 0644)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This information isn't particularly sensitive, and tools sometimes run as different users, especially in a containerized environment (root vs nonroot, in Google Cloud Build, Tekton, etc).

Allow the file to be read by other users.
