### PR TITLE
WIP: warn if the build depends on the default base image

### DIFF
--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -30,11 +30,6 @@ import (
 	"github.com/google/ko/pkg/build"
 )
 
-const (
-	// configDefaultBaseImage is the default base image if not specified in .ko.yaml.
-	configDefaultBaseImage = "gcr.io/distroless/static:nonroot"
-)
-
 // BuildOptions represents options for the ko builder.
 type BuildOptions struct {
 	// BaseImage enables setting the default base image programmatically.
@@ -89,8 +84,6 @@ func (bo *BuildOptions) LoadConfig() error {
 	if bo.WorkingDirectory == "" {
 		bo.WorkingDirectory = "."
 	}
-	// If omitted, use this base image.
-	v.SetDefault("defaultBaseImage", configDefaultBaseImage)
 	const configName = ".ko"
 
 	v.SetConfigName(configName) // .yaml is implicit
@@ -128,10 +121,12 @@ func (bo *BuildOptions) LoadConfig() error {
 
 	if bo.BaseImage == "" {
 		ref := v.GetString("defaultBaseImage")
-		if _, err := name.ParseReference(ref); err != nil {
-			return fmt.Errorf("'defaultBaseImage': error parsing %q as image reference: %w", ref, err)
+		if ref != "" {
+			if _, err := name.ParseReference(ref); err != nil {
+				return fmt.Errorf("'defaultBaseImage': error parsing %q as image reference: %w", ref, err)
+			}
+			bo.BaseImage = ref
 		}
-		bo.BaseImage = ref
 	}
 
 	if len(bo.BaseImageOverrides) == 0 {


### PR DESCRIPTION
Tested:

- if `.ko.yaml` is empty or non-existent --> warning
- if `.ko.yaml` specifies any `defaultBaseImage` --> no warning
- if `.ko.yaml` specifies `baseImageOverrides` matching all requested builds --> no warning

Progress toward #722 

---

```
➜  ko git:(default-base-image-warning) go run ./ build ./ 
2022/06/21 13:20:30 Using base golang:1.17@sha256:095eb1b2178f83935a6f43e53d61b54d0426149e54a82e9789f4b8f7f20c8125 for github.com/google/ko
...
➜  ko git:(default-base-image-warning) rm .ko.yaml 
➜  ko git:(default-base-image-warning) ✗ go run ./ build ./ 
2022/06/21 13:20:46 NOTICE!
-----------------------------------------------------------------
The default base image used by ko is changing in a future release, from:

    gcr.io/distroless/static:nonroot

to:

    ghcr.io/distroless/static:latest

To retain the existing default, add this to your .ko.yaml:

    defaultBaseImage: gcr.io/distroless/static:nonroot

To opt-in to the new behavior now, add this:

    defaultBaseImage: ghcr.io/distroless/static:latest

For more information see:
    https://github.com/google/ko/issues/722
-----------------------------------------------------------------
2022/06/21 13:20:49 Using base gcr.io/distroless/static:nonroot@sha256:66cd130e90992bebb68b8735a72f8ad154d0cd4a6f3a8b76f1e372467818d1b4 for github.com/google/ko
```

---

Separate from this, we should figure out if we want to include tzdata in built binaries by default, ahead of the switch to the tzdata-less distroless base image.