### PR TITLE
Update base image to ghcr.io/distroless/static:latest

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,7 +50,7 @@ jobs:
 
         # Build and run the test/ binary, which should log "Hello there" served from KO_DATA_PATH
         testimg=$(go run ./ build ./test --platform=${PLATFORM} --preserve-import-paths)
-        docker run ${testimg} --wait=false 2>&1 | grep "Hello there"
+        docker run ${testimg} --wait=false 2>&1 | tee >(grep "Hello there") # Log all output too.
 
         # Check that symlinks in kodata are chased.
         # Skip this test on Windows.

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// configDefaultBaseImage is the default base image if not specified in .ko.yaml.
-	configDefaultBaseImage = "gcr.io/distroless/static:nonroot"
+	configDefaultBaseImage = "ghcr.io/distroless/static:latest"
 )
 
 // BuildOptions represents options for the ko builder.

--- a/pkg/commands/options/build_test.go
+++ b/pkg/commands/options/build_test.go
@@ -32,7 +32,7 @@ func TestDefaultBaseImage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wantDefaultBaseImage := "gcr.io/distroless/base:nonroot" // matches value in ./testdata/.ko.yaml
+	wantDefaultBaseImage := "alpine" // matches value in ./testdata/config/.ko.yaml
 	if bo.BaseImage != wantDefaultBaseImage {
 		t.Fatalf("wanted BaseImage %s, got %s", wantDefaultBaseImage, bo.BaseImage)
 	}

--- a/pkg/commands/options/testdata/config/.ko.yaml
+++ b/pkg/commands/options/testdata/config/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: gcr.io/distroless/base:nonroot
+defaultBaseImage: alpine

--- a/test/main.go
+++ b/test/main.go
@@ -16,12 +16,14 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	// Give this an interesting import
 	_ "github.com/google/go-containerregistry/pkg/registry"
@@ -39,6 +41,14 @@ func main() {
 	flag.Parse()
 
 	log.Println("version =", version)
+
+	// Exercise timezone conversions, which demonstrates tzdata is provided
+	// by the base image.
+	now := time.Now()
+	loc, _ := time.LoadLocation("UTC")
+	fmt.Printf("UTC Time: %s\n", now.In(loc))
+	loc, _ = time.LoadLocation("America/New_York")
+	fmt.Printf("New York Time: %s\n", now.In(loc))
 
 	dp := os.Getenv("KO_DATA_PATH")
 	file := filepath.Join(dp, *f)


### PR DESCRIPTION
Fixes #722 

`ghcr.io/distroless/static` now includes tzdata, but this also adds a test that ensures timezone conversions are unaffected in case we change the base image again in the future.

I don't want to update the README until after we cut a release.