### PR TITLE
Fix off-by-one error

### DIFF
--- a/internal/sbom/cyclonedx.go
+++ b/internal/sbom/cyclonedx.go
@@ -37,7 +37,7 @@ func goRef(path, version string) string {
 		path = strings.Join(
 			append(
 				[]string{strings.ToLower(p[0]), strings.ToLower(p[1])},
-				p[2:(len(p)-1)]...,
+				p[2:]...,
 			), "/",
 		)
 	}


### PR DESCRIPTION
Use the simpler syntax `[2:]` to avoid the off-by-one in the length calculation.