### PR TITLE
Unconditionally set the base image annotation.

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -889,8 +889,8 @@ func (g *gobuild) Build(ctx context.Context, s string) (Result, error) {
 
 		anns := map[string]string{
 			specsv1.AnnotationBaseImageDigest: baseDigest.String(),
+			specsv1.AnnotationBaseImageName:   baseRef.Name(),
 		}
-		anns[specsv1.AnnotationBaseImageName] = baseRef.Name()
 		base = mutate.Annotations(base, anns).(Result)
 	}
 

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -890,9 +890,7 @@ func (g *gobuild) Build(ctx context.Context, s string) (Result, error) {
 		anns := map[string]string{
 			specsv1.AnnotationBaseImageDigest: baseDigest.String(),
 		}
-		if _, ok := baseRef.(name.Tag); ok {
-			anns[specsv1.AnnotationBaseImageName] = baseRef.Name()
-		}
+		anns[specsv1.AnnotationBaseImageName] = baseRef.Name()
 		base = mutate.Annotations(base, anns).(Result)
 	}
 


### PR DESCRIPTION
Previously we only set this annotation when our base image was a tag, but this means when folks actually follow the best practice of use digest base images they get strictly worse resulting images!

It sounds like maybe the original motivation for this condition was that it was supposed to contain the mutable reference (tag), but I don't see anything detailing such a restriction (just an example), so there should be nothing
precluding this from the spec.