### PR TITLE
ko run: remove --generator flag

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -67,7 +67,7 @@ func addRun(topLevel *cobra.Command) {
 
 			kubectlArgs := []string{}
 			dashes = unparsedDashes()
-			if dashes != -1 {
+			if dashes != -1 && dashes != len(os.Args) {
 				kubectlArgs = os.Args[dashes+1:]
 			}
 

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -68,7 +68,7 @@ func addRun(topLevel *cobra.Command) {
 			kubectlArgs := []string{}
 			dashes = unparsedDashes()
 			if dashes != -1 {
-				kubectlArgs = os.Args[dashes:]
+				kubectlArgs = os.Args[dashes+1:]
 			}
 
 			bo.InsecureRegistry = po.InsecureRegistry

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -102,7 +102,6 @@ func addRun(topLevel *cobra.Command) {
 
 				// These are better defaults:
 				defaults := []string{
-					"--generator=run-pod/v1",   // create a pod instead of deployment
 					"--attach",                 // stream logs back
 					"--rm",                     // clean up after ourselves
 					"--restart=Never",          // we just want to run once


### PR DESCRIPTION
See https://github.com/google/ko/issues/747 -- `--generator` has been deprecated and remove from `kubectl`.

`kubectl run` seems to create Pods by default, so the flag wasn't necessary.

If we decide to keep `ko run` around, we should probably exercise it in some e2e test so that future similar `kubectl` changes are detected earlier.

This change also fixes an off-by-one error when handling `--`, which led to flags to kubectl being dropped. More signal that we should either use this, test it, or drop it.

Fixes #762 
Fixes #747