### PR TITLE
Reject the -toolexec flag

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -688,6 +688,16 @@ func createBuildArgs(buildCfg Config) ([]string, error) {
 		args = append(args, fmt.Sprintf("-ldflags=%s", strings.Join(buildCfg.Ldflags, " ")))
 	}
 
+	// Reject any flags that attempt to set --toolexec (with or
+	// without =, with one or two -s)
+	for _, a := range args {
+		for _, d := range []string{"-", "--"} {
+			if a == d+"toolexec" || strings.HasPrefix(a, d+"toolexec=") {
+				return nil, fmt.Errorf("cannot set %s", a)
+			}
+		}
+	}
+
 	return args, nil
 }
 

--- a/test/build-configs/.ko.yaml
+++ b/test/build-configs/.ko.yaml
@@ -19,3 +19,9 @@ builds:
 - id: bar-app
   dir: ./bar
   main: ./cmd
+- id: toolexec
+  dir: ./toolexec
+  main: ./cmd
+  flags:
+  - -toolexec
+  - go

--- a/test/build-configs/toolexec/cmd/main.go
+++ b/test/build-configs/toolexec/cmd/main.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("toolexec")
+}

--- a/test/build-configs/toolexec/go.mod
+++ b/test/build-configs/toolexec/go.mod
@@ -1,0 +1,17 @@
+// Copyright 2022 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module example.com/toolexec
+
+go 1.16


### PR DESCRIPTION
This came up in the discussion of https://github.com/google/ko/issues/684 -- the `-toolexec` flag makes `go build` execute another command, and generally represents pretty non-standard, advanced usage. A bad build config could set `-toolexec not-go` and get `not-go` to be executed by `go` instead of the regular Go toolchain.

`ko` aims to make normal usage easy and secure, even if it rejects advanced use cases (e.g., `CGO_ENABLED`), so we'll just reject `-trimpath` if it's requested.