### PR TITLE
Ignore not-found errors when evaling symlinks; just log and keep walking

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -539,7 +539,10 @@ func walkRecursive(tw *tar.Writer, root, chroot string, creationTime v1.Time, pl
 		}
 
 		evalPath, err := filepath.EvalSymlinks(hostPath)
-		if err != nil {
+		if os.IsNotExist(err) {
+			log.Printf("skipping symlink for %q: %v", hostPath, err)
+			return nil
+		} else if err != nil {
 			return fmt.Errorf("filepath.EvalSymlinks(%q): %w", hostPath, err)
 		}
 


### PR DESCRIPTION
If you run our unit tests without a `.git` directory (as alpine packaging tests seem to do), lots of tests fail with:

```
        resolver_test.go:225: builder.Build(): filepath.EvalSymlinks("/Users/jason/git/ko2/test/kodata/HEAD"): lstat /Users/jason/git/ko2/.git: no such file or directory
```

This is because our `./test/kodata/HEAD` is a symlink to `.git/HEAD`, which doesn't exist when tested in that way.

Instead of failing, this changes `ko` to log and ignore when a symlink in `kodata` points to a file that doesn't exist.