### PR TITLE
don't fail if LDFLAGS env isn't set

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,2 +1,7 @@
 baseImageOverrides:
   github.com/google/ko: golang:1.17
+
+builds:
+- id: ko
+  ldflags:
+  - "{{ .Env.LDFLAGS }}"

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -638,7 +638,9 @@ func (g *gobuild) tarKoData(ref reference, platform *v1.Platform) (*bytes.Buffer
 }
 
 func createTemplateData() map[string]interface{} {
-	envVars := map[string]string{}
+	envVars := map[string]string{
+		"LDFLAGS": "",
+	}
 	for _, entry := range os.Environ() {
 		kv := strings.SplitN(entry, "=", 2)
 		envVars[kv[0]] = kv[1]


### PR DESCRIPTION
Without this, if a `.ko.yaml` has:

```
builds:
- id: foo
  ldflags:
  - "{{ .Env.LDFLAGS }}"
```

(usually to set build-time VCS data like commit SHA, etc.)

If `LDFLAGS` isn't set, you'll get an error like:

```
Error: failed to publish images: error building "ko://blah/blah": template: argsTmpl:1:7: executing "argsTmpl" at <.Env.LDFLAGS>: map has no entry for key "LDFLAGS"
```

which is very annoying.

With this change, the build will succeed, without any additional `-ldflags` being set on the build.