### PR TITLE
Chore: bumped base image to go 1.18

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,5 +1,5 @@
 baseImageOverrides:
-  github.com/google/ko: golang:1.17
+  github.com/google/ko: golang:1.18
 
 builds:
 - id: ko


### PR DESCRIPTION
### Rationale
I'd like to use ghcr.io/google/ko in a tekton pipeline to build karpenter which uses go 1.18.

### Testing
#### Manual
Before
```
2022/07/13 23:53:57 logged in via /root/.docker/config.json
2022/07/13 23:54:46 Using base [ghcr.io/distroless/static:latest@sha256:9a2c27a6be0723f18630c26f601fc83a2bee1af0706906a694df3fda05a32267](http://ghcr.io/distroless/static:latest@sha256:9a2c27a6be0723f18630c26f601fc83a2bee1af0706906a694df3fda05a32267) for cmd/controller/main.go
2022/07/13 23:54:47 Building cmd/controller/main.go for linux/amd64
2022/07/14 00:01:33 Unexpected error running "go build": exit status 2
# [golang.org/x/exp/constraints](http://golang.org/x/exp/constraints)
/go/pkg/mod/golang.org/x/exp@v0.0.0-20220303212507-bbda1eaf7a17/constraints/constraints.go:13:2: syntax error: unexpected ~, expecting method or interface name
/go/pkg/mod/golang.org/x/exp@v0.0.0-20220303212507-bbda1eaf7a17/constraints/constraints.go:20:2: syntax error: unexpected ~, expecting method or interface name
/go/pkg/mod/golang.org/x/exp@v0.0.0-20220303212507-bbda1eaf7a17/constraints/constraints.go:27:9: syntax error: unexpected |, expecting semicolon or newline or }
/go/pkg/mod/golang.org/x/exp@v0.0.0-20220303212507-bbda1eaf7a17/constraints/constraints.go:34:2: syntax error: unexpected ~, expecting method or interface name
/go/pkg/mod/golang.org/x/exp@v0.0.0-20220303212507-bbda1eaf7a17/constraints/constraints.go:41:2: syntax error: unexpected ~, expecting method or interface name
/go/pkg/mod/golang.org/x/exp@v0.0.0-20220303212507-bbda1eaf7a17/constraints/constraints.go:49:10: syntax error: unexpected |, expecting semicolon or newline or }
note: module requires Go 1.18
Error: failed to publish images: error building "ko://cmd/controller/main.go": exit status 2
2022/07/14 00:01:33 error during command execution:failed to publish images: error building "ko://cmd/controller/main.go": exit status 2
```
After
```
❯ /Users/etarn/workspaces/go/src/github.com/ko/ko build -B github.com/aws/karpenter/cmd/controller --sbom none

2022/07/14 10:29:47 Using base ghcr.io/distroless/static:latest@sha256:691a0ecea382d18707d4b15f5de0b7a9a3003e4280fb0d9d4e4b1b11fb4b94d3 for github.com/aws/karpenter/cmd/controller
2022/07/14 10:29:48 Building github.com/aws/karpenter/cmd/controller for linux/amd64
2022/07/14 10:29:51 Publishing 767520670908.dkr.ecr.us-west-2.amazonaws.com/karpenter/controller:latest
2022/07/14 10:29:52 existing blob: sha256:4a7698fa7eb7ea8a38dbf566836f459402cbfae6157d50319e5e9bf814aafaf0
2022/07/14 10:29:52 existing blob: sha256:b3fe57f1a791689231674f12863b97d4fdfdcbf658a0d3f09a788c254be623e3
2022/07/14 10:29:52 pushed blob: sha256:4ed9054cd0c4fb6ad0138ba785d19f0a3aeeb65e1418fb04c664e4ecb2ae0c09
2022/07/14 10:29:53 pushed blob: sha256:bcdb7865688ff74e4d54348613517a6ef19322abafa3d2b267acbaab999c4c93
2022/07/14 10:29:53 767520670908.dkr.ecr.us-west-2.amazonaws.com/karpenter/controller:latest: digest: sha256:10d1b55141964533db55adee2b386b350a2c30fa236d5a3dc20dba9202db1bc8 size: 932
2022/07/14 10:29:53 Published 767520670908.dkr.ecr.us-west-2.amazonaws.com/karpenter/controller@sha256:10d1b55141964533db55adee2b386b350a2c30fa236d5a3dc20dba9202db1bc8
767520670908.dkr.ecr.us-west-2.amazonaws.com/karpenter/controller@sha256:10d1b55141964533db55adee2b386b350a2c30fa236d5a3dc20dba9202db1bc8
```

#### Integration
```
❯ ./integration_test.sh
~/workspaces/go/src/github.com/ko ~/workspaces/go/src/github.com/ko
Moving GOPATH into /tmp/ to test modules behavior.
/var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0 ~/workspaces/go/src/github.com/ko ~/workspaces/go/src/github.com/ko
Copying ko to temp gopath.
Downloading github.com/go-training/helloworld
/var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0/src/github.com/google/ko /var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0 ~/workspaces/go/src/github.com/ko ~/workspaces/go/src/github.com/ko
Replacing hello world in vendor with TEST.
Building ko
Beginning scenarios.
1. GOPATH mode should always create an image that outputs 'Hello World'
2022/07/14 09:37:23 Using base ghcr.io/distroless/static:latest@sha256:691a0ecea382d18707d4b15f5de0b7a9a3003e4280fb0d9d4e4b1b11fb4b94d3 for github.com/go-training/helloworld
2022/07/14 09:37:24 Building github.com/go-training/helloworld for linux/amd64
2022/07/14 09:37:24 Loading ko.local/helloworld-4a5df22c048e79e965f786183fbaaa39:6aaf9e128da6f69204d496d9a04d60a6c72572e38b029bb537509c0d057b95c1
2022/07/14 09:37:25 Loaded ko.local/helloworld-4a5df22c048e79e965f786183fbaaa39:6aaf9e128da6f69204d496d9a04d60a6c72572e38b029bb537509c0d057b95c1
2022/07/14 09:37:25 Adding tag latest
2022/07/14 09:37:25 Added tag latest
Test PASSED
2. Go module auto mode should create an image that outputs 'Hello World' when run outside the module.
/var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0/src/github.com/google /var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0/src/github.com/google/ko /var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0 ~/workspaces/go/src/github.com/ko ~/workspaces/go/src/github.com/ko
2022/07/14 09:37:27 Using base ghcr.io/distroless/static:latest@sha256:691a0ecea382d18707d4b15f5de0b7a9a3003e4280fb0d9d4e4b1b11fb4b94d3 for github.com/go-training/helloworld
2022/07/14 09:37:27 Building github.com/go-training/helloworld for linux/amd64
2022/07/14 09:37:28 Loading ko.local/helloworld-4a5df22c048e79e965f786183fbaaa39:6aaf9e128da6f69204d496d9a04d60a6c72572e38b029bb537509c0d057b95c1
2022/07/14 09:37:28 Loaded ko.local/helloworld-4a5df22c048e79e965f786183fbaaa39:6aaf9e128da6f69204d496d9a04d60a6c72572e38b029bb537509c0d057b95c1
2022/07/14 09:37:28 Adding tag latest
2022/07/14 09:37:28 Added tag latest
Test PASSED
/var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0/src/github.com/google/ko /var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0 ~/workspaces/go/src/github.com/ko ~/workspaces/go/src/github.com/ko
3. Auto inside the module with vendoring should output TEST
2022/07/14 09:37:29 Using base ghcr.io/distroless/static:latest@sha256:691a0ecea382d18707d4b15f5de0b7a9a3003e4280fb0d9d4e4b1b11fb4b94d3 for github.com/go-training/helloworld
2022/07/14 09:37:29 Building github.com/go-training/helloworld for linux/amd64
2022/07/14 09:37:34 Loading ko.local/helloworld-4a5df22c048e79e965f786183fbaaa39:c784b5c02c0ecd719556c0ddabc6f1be3016f66cd54c0db2365a3abce877396a
2022/07/14 09:37:35 Loaded ko.local/helloworld-4a5df22c048e79e965f786183fbaaa39:c784b5c02c0ecd719556c0ddabc6f1be3016f66cd54c0db2365a3abce877396a
2022/07/14 09:37:35 Adding tag latest
2022/07/14 09:37:35 Added tag latest
Test PASSED
4. Auto inside the module without vendoring should output TEST
2022/07/14 09:37:36 Using base ghcr.io/distroless/static:latest@sha256:691a0ecea382d18707d4b15f5de0b7a9a3003e4280fb0d9d4e4b1b11fb4b94d3 for github.com/go-training/helloworld
2022/07/14 09:37:37 Building github.com/go-training/helloworld for linux/amd64
2022/07/14 09:37:37 Loading ko.local/helloworld-4a5df22c048e79e965f786183fbaaa39:c784b5c02c0ecd719556c0ddabc6f1be3016f66cd54c0db2365a3abce877396a
2022/07/14 09:37:37 Loaded ko.local/helloworld-4a5df22c048e79e965f786183fbaaa39:c784b5c02c0ecd719556c0ddabc6f1be3016f66cd54c0db2365a3abce877396a
2022/07/14 09:37:37 Adding tag latest
2022/07/14 09:37:37 Added tag latest
Test PASSED
5. On inside the module with vendor should output TEST.
2022/07/14 09:37:38 Using base ghcr.io/distroless/static:latest@sha256:691a0ecea382d18707d4b15f5de0b7a9a3003e4280fb0d9d4e4b1b11fb4b94d3 for github.com/go-training/helloworld
2022/07/14 09:37:39 Building github.com/go-training/helloworld for linux/amd64
2022/07/14 09:37:39 Loading ko.local/helloworld-4a5df22c048e79e965f786183fbaaa39:c784b5c02c0ecd719556c0ddabc6f1be3016f66cd54c0db2365a3abce877396a
2022/07/14 09:37:39 Loaded ko.local/helloworld-4a5df22c048e79e965f786183fbaaa39:c784b5c02c0ecd719556c0ddabc6f1be3016f66cd54c0db2365a3abce877396a
2022/07/14 09:37:39 Adding tag latest
2022/07/14 09:37:39 Added tag latest
Test PASSED
6. On inside the module without vendor should output TEST
2022/07/14 09:37:41 Using base ghcr.io/distroless/static:latest@sha256:691a0ecea382d18707d4b15f5de0b7a9a3003e4280fb0d9d4e4b1b11fb4b94d3 for github.com/go-training/helloworld
2022/07/14 09:37:41 Building github.com/go-training/helloworld for linux/amd64
2022/07/14 09:37:41 Loading ko.local/helloworld-4a5df22c048e79e965f786183fbaaa39:c784b5c02c0ecd719556c0ddabc6f1be3016f66cd54c0db2365a3abce877396a
2022/07/14 09:37:42 Loaded ko.local/helloworld-4a5df22c048e79e965f786183fbaaa39:c784b5c02c0ecd719556c0ddabc6f1be3016f66cd54c0db2365a3abce877396a
2022/07/14 09:37:42 Adding tag latest
2022/07/14 09:37:42 Added tag latest
Test PASSED
7. On outside the module should fail.
/var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0/src/github.com/google /var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0/src/github.com/google/ko /var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0 ~/workspaces/go/src/github.com/ko ~/workspaces/go/src/github.com/ko
Error: failed to publish images: importpath "ko://github.com/go-training/helloworld" is not supported: importpath is not `package main`
2022/07/14 09:37:42 error during command execution:failed to publish images: importpath "ko://github.com/go-training/helloworld" is not supported: importpath is not `package main`
/var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0/src/github.com/google/ko /var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0 ~/workspaces/go/src/github.com/ko ~/workspaces/go/src/github.com/ko
8. On outside with build config specifying the test module builds.
/var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0/src/github.com/google/ko/test/build-configs /var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0/src/github.com/google/ko /var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0 ~/workspaces/go/src/github.com/ko ~/workspaces/go/src/github.com/ko
2022/07/14 09:37:43 Using base ghcr.io/distroless/static:latest@sha256:691a0ecea382d18707d4b15f5de0b7a9a3003e4280fb0d9d4e4b1b11fb4b94d3 for example.com/foo/cmd
2022/07/14 09:37:43 Using build config foo-app for example.com/foo/cmd
2022/07/14 09:37:43 Building example.com/foo/cmd for linux/amd64
2022/07/14 09:37:44 Loading ko.local/cmd-e1b18d3f9440f88deb6cd566424f231c:392803d48724a8dcca854ef7f49d183fa9088050fa34f4940baab74bfc466aba
2022/07/14 09:37:44 Loaded ko.local/cmd-e1b18d3f9440f88deb6cd566424f231c:392803d48724a8dcca854ef7f49d183fa9088050fa34f4940baab74bfc466aba
2022/07/14 09:37:44 Adding tag latest
2022/07/14 09:37:44 Added tag latest
Test PASSED for example.com/foo/cmd
2022/07/14 09:37:46 Using base ghcr.io/distroless/static:latest@sha256:691a0ecea382d18707d4b15f5de0b7a9a3003e4280fb0d9d4e4b1b11fb4b94d3 for example.com/foo/cmd
2022/07/14 09:37:46 Using build config foo-app for example.com/foo/cmd
2022/07/14 09:37:46 Building example.com/foo/cmd for linux/amd64
2022/07/14 09:37:46 Loading ko.local/cmd-e1b18d3f9440f88deb6cd566424f231c:392803d48724a8dcca854ef7f49d183fa9088050fa34f4940baab74bfc466aba
2022/07/14 09:37:47 Loaded ko.local/cmd-e1b18d3f9440f88deb6cd566424f231c:392803d48724a8dcca854ef7f49d183fa9088050fa34f4940baab74bfc466aba
2022/07/14 09:37:47 Adding tag latest
2022/07/14 09:37:47 Added tag latest
Test PASSED for ./foo/cmd
2022/07/14 09:37:48 Using base ghcr.io/distroless/static:latest@sha256:691a0ecea382d18707d4b15f5de0b7a9a3003e4280fb0d9d4e4b1b11fb4b94d3 for example.com/bar/cmd
2022/07/14 09:37:49 Using build config bar-app for example.com/bar/cmd
2022/07/14 09:37:49 Building example.com/bar/cmd for linux/amd64
2022/07/14 09:37:49 Loading ko.local/cmd-4a6cabc42c8494663ec604436ca73ebd:0de76e3f76fa2e64e32802b14bc5a328edc6459776b3e704007a8ef4206fbeb8
2022/07/14 09:37:50 Loaded ko.local/cmd-4a6cabc42c8494663ec604436ca73ebd:0de76e3f76fa2e64e32802b14bc5a328edc6459776b3e704007a8ef4206fbeb8
2022/07/14 09:37:50 Adding tag latest
2022/07/14 09:37:50 Added tag latest
Test PASSED for example.com/bar/cmd
2022/07/14 09:37:51 Using base ghcr.io/distroless/static:latest@sha256:691a0ecea382d18707d4b15f5de0b7a9a3003e4280fb0d9d4e4b1b11fb4b94d3 for example.com/bar/cmd
2022/07/14 09:37:52 Using build config bar-app for example.com/bar/cmd
2022/07/14 09:37:52 Building example.com/bar/cmd for linux/amd64
2022/07/14 09:37:52 Loading ko.local/cmd-4a6cabc42c8494663ec604436ca73ebd:0de76e3f76fa2e64e32802b14bc5a328edc6459776b3e704007a8ef4206fbeb8
2022/07/14 09:37:52 Loaded ko.local/cmd-4a6cabc42c8494663ec604436ca73ebd:0de76e3f76fa2e64e32802b14bc5a328edc6459776b3e704007a8ef4206fbeb8
2022/07/14 09:37:52 Adding tag latest
2022/07/14 09:37:52 Added tag latest
Test PASSED for ./bar/cmd
/var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0/src/github.com/google/ko /var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0 ~/workspaces/go/src/github.com/ko ~/workspaces/go/src/github.com/ko
/var/folders/w2/m81nbd9n4flbjmmz5vbn0g1dh_j06n/T/tmp.BIkDfez0 ~/workspaces/go/src/github.com/ko ~/workspaces/go/src/github.com/ko
~/workspaces/go/src/github.com/ko ~/workspaces/go/src/github.com/ko
```