### PR TITLE
fix GitHub Actions workflows

### DIFF
--- a/.github/workflows/go-1.18.yaml
+++ b/.github/workflows/go-1.18.yaml
@@ -30,6 +30,6 @@ jobs:
         go-version: ${{ matrix.user-go-version }}
         check-latest: true
     - uses: chainguard-dev/actions/setup-registry@main
-    - with:
+    - env:
         KO_DOCKER_REPO: localhost:1338
       run: ko build ./test/


### PR DESCRIPTION
I messed this up in #772 -- the test needs `env:` instead of `with:` (which requires a `uses:`)