### PR TITLE
Add tests that ko can push to quay.io and Dockerhub

### DIFF
--- a/.github/workflows/quay.yaml
+++ b/.github/workflows/quay.yaml
@@ -1,0 +1,28 @@
+name: Push to quay.io
+
+on:
+  pull_request_target:
+    branches: ['main']
+  push:
+    branches: ['main']
+  workload_dispatch:
+
+jobs:
+  quay:
+    name: Push to quay.io
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version: 1.18
+        check-latest: true
+    - env:
+        QUAY_USERNAME: ko-testing
+        QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+        KO_DOCKER_REPO: quay.io/ko-testing/test
+      run: |
+        echo ${QUAY_PASSWORD} | go run ./ login --username=${QUAY_USERNAME} --password-stdin quay.io
+        go run ./ build --platform=all ./test/
+

--- a/.github/workflows/registries.yaml
+++ b/.github/workflows/registries.yaml
@@ -5,7 +5,7 @@ on:
     branches: ['main']
   push:
     branches: ['main']
-  workload_dispatch:
+  workflow_dispatch:  # Allow manual runs.
 
 jobs:
   quay:

--- a/.github/workflows/registries.yaml
+++ b/.github/workflows/registries.yaml
@@ -1,4 +1,4 @@
-name: Push to quay.io
+name: Push to registries
 
 on:
   pull_request_target:
@@ -26,3 +26,20 @@ jobs:
         echo ${QUAY_PASSWORD} | go run ./ login --username=${QUAY_USERNAME} --password-stdin quay.io
         go run ./ build --platform=all ./test/
 
+  dockerhub:
+    name: Push to dockerhub
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version: 1.18
+        check-latest: true
+    - env:
+        DOCKERHUB_USERNAME: kotesting
+        DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        KO_DOCKER_REPO: kotesting/test
+      run: |
+        echo ${DOCKERHUB_PASSWORD} | go run ./ login --username=${DOCKERHUB_USERNAME} --password-stdin index.docker.io
+        go run ./ build --platform=all ./test/


### PR DESCRIPTION
These rely on long-lived credentials stored in GitHub repository secrets.

We should also investigate adding tests for ECR and GCR using OIDC credentials, probably reusing those used by go-containerregistry.