### PR TITLE
Error if image platform does not match desired

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -757,6 +757,9 @@ func (g *gobuild) buildOne(ctx context.Context, refStr string, base v1.Image, pl
 		}
 	}
 
+	if !g.platformMatcher.matches(platform) {
+		return nil, fmt.Errorf("base image platform %q does not match desired platforms %v", platform, g.platformMatcher.platforms)
+	}
 	// Do the build into a temporary file.
 	file, err := g.build(ctx, ref.Path(), g.dir, *platform, g.configForImportPath(ref.Path()))
 	if err != nil {

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -437,6 +437,7 @@ func TestGoBuildNoKoData(t *testing.T) {
 		WithBaseImages(func(context.Context, string) (name.Reference, Result, error) { return baseRef, base, nil }),
 		withBuilder(writeTempFile),
 		withSBOMber(fauxSBOM),
+		WithPlatforms("all"),
 	)
 	if err != nil {
 		t.Fatalf("NewGo() = %v", err)
@@ -719,6 +720,7 @@ func TestGoBuild(t *testing.T) {
 		withSBOMber(fauxSBOM),
 		WithLabel("foo", "bar"),
 		WithLabel("hello", "world"),
+		WithPlatforms("all"),
 	)
 	if err != nil {
 		t.Fatalf("NewGo() = %v", err)
@@ -794,6 +796,7 @@ func TestGoBuildWithKOCACHE(t *testing.T) {
 		"",
 		WithCreationTime(creationTime),
 		WithBaseImages(func(context.Context, string) (name.Reference, Result, error) { return baseRef, base, nil }),
+		WithPlatforms("all"),
 	)
 	if err != nil {
 		t.Fatalf("NewGo() = %v", err)
@@ -831,6 +834,7 @@ func TestGoBuildWithoutSBOM(t *testing.T) {
 		WithLabel("foo", "bar"),
 		WithLabel("hello", "world"),
 		WithDisabledSBOM(),
+		WithPlatforms("all"),
 	)
 	if err != nil {
 		t.Fatalf("NewGo() = %v", err)
@@ -1183,6 +1187,7 @@ func TestGoBuildConsistentMediaTypes(t *testing.T) {
 				WithBaseImages(func(context.Context, string) (name.Reference, Result, error) { return baseRef, base, nil }),
 				withBuilder(writeTempFile),
 				withSBOMber(fauxSBOM),
+				WithPlatforms("all"),
 			)
 			if err != nil {
 				t.Fatalf("NewGo() = %v", err)

--- a/pkg/build/gobuilds_test.go
+++ b/pkg/build/gobuilds_test.go
@@ -31,6 +31,7 @@ func Test_gobuilds(t *testing.T) {
 	opts := []Option{
 		WithBaseImages(func(context.Context, string) (name.Reference, Result, error) { return baseRef, base, nil }),
 		withBuilder(writeTempFile),
+		WithPlatforms("all"),
 	}
 
 	tests := []struct {

--- a/pkg/commands/publisher_test.go
+++ b/pkg/commands/publisher_test.go
@@ -66,6 +66,7 @@ func TestPublishImages(t *testing.T) {
 		bo := &options.BuildOptions{
 			BaseImage:        baseImage,
 			ConcurrentBuilds: 1,
+			Platforms:        []string{"all"},
 		}
 		builder, err := NewBuilder(ctx, bo)
 		if err != nil {

--- a/pkg/commands/resolver_test.go
+++ b/pkg/commands/resolver_test.go
@@ -183,6 +183,7 @@ func TestNewBuilder(t *testing.T) {
 			bo: &options.BuildOptions{
 				BaseImage:        baseImage,
 				ConcurrentBuilds: 1,
+				Platforms:        []string{"all"},
 			},
 			wantQualifiedImportpath: "ko://github.com/google/ko/test",
 			shouldBuildError:        false,


### PR DESCRIPTION
Fixes #699

If the user specifies an image manifest and its platform does not match the platforms specified or defaulted, error out.

With a `.ko.yaml` specifying the linux/amd64 image manifest instead of the multi-platform index:
```yaml
baseImageOverrides:
  github.com/google/ko: golang@sha256:a4081692fa3015104d84b125cbf623c566a0c9e2a39b9a29f6d939225d5687a4
```


## Prior behavior
```
❯ go run main.go build --platform=linux/arm64 .
2022/08/04 10:36:41 No matching credentials were found, falling back on anonymous
2022/08/04 10:36:42 Using base golang@sha256:a4081692fa3015104d84b125cbf623c566a0c9e2a39b9a29f6d939225d5687a4 for github.com/google/ko
2022/08/04 10:36:42 Building github.com/google/ko for linux/amd64
...
```

## New behavior
```
❯ go run main.go build --platform=linux/arm64 .
2022/08/04 10:43:52 No matching credentials were found, falling back on anonymous
2022/08/04 10:43:53 Using base golang@sha256:a4081692fa3015104d84b125cbf623c566a0c9e2a39b9a29f6d939225d5687a4 for github.com/google/ko
Error: failed to publish images: error building "ko://github.com/google/ko": base image platform "linux/amd64" does not match desired platforms [linux/arm64]
2022/08/04 10:43:53 error during command execution:failed to publish images: error building "ko://github.com/google/ko": base image platform "linux/amd64" does not match desired platforms [linux/arm64]
exit status 1
```

As mentioned in #699 `--platform=all` is a lil ambiguous so we're keeping that behavior:
```
❯ go run main.go build --platform=all .
2022/08/04 10:45:40 No matching credentials were found, falling back on anonymous
2022/08/04 10:45:41 Using base golang@sha256:a4081692fa3015104d84b125cbf623c566a0c9e2a39b9a29f6d939225d5687a4 for github.com/google/ko
2022/08/04 10:45:41 Building github.com/google/ko for linux/amd64
...
```