### PR TITLE
expose commands.ResolveFilesToWriter() method

### DIFF
--- a/pkg/commands/apply.go
+++ b/pkg/commands/apply.go
@@ -114,7 +114,7 @@ func addApply(topLevel *cobra.Command) {
 					stdin.Write([]byte("---\n"))
 				}
 				// Once primed kick things off.
-				return resolveFilesToWriter(ctx, builder, publisher, fo, so, stdin)
+				return ResolveFilesToWriter(ctx, builder, publisher, fo, so, stdin)
 			})
 
 			g.Go(func() error {

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -115,7 +115,7 @@ func addCreate(topLevel *cobra.Command) {
 					stdin.Write([]byte("---\n"))
 				}
 				// Once primed kick things off.
-				return resolveFilesToWriter(ctx, builder, publisher, fo, so, stdin)
+				return ResolveFilesToWriter(ctx, builder, publisher, fo, so, stdin)
 			})
 
 			g.Go(func() error {

--- a/pkg/commands/resolve.go
+++ b/pkg/commands/resolve.go
@@ -71,7 +71,7 @@ func addResolve(topLevel *cobra.Command) {
 				return fmt.Errorf("error creating publisher: %w", err)
 			}
 			defer publisher.Close()
-			return resolveFilesToWriter(ctx, builder, publisher, fo, so, os.Stdout)
+			return ResolveFilesToWriter(ctx, builder, publisher, fo, so, os.Stdout)
 		},
 	}
 	options.AddPublishArg(resolve, po)

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -272,7 +272,7 @@ func (n nopPublisher) Close() error { return nil }
 // resolvedFuture represents a "future" for the bytes of a resolved file.
 type resolvedFuture chan []byte
 
-func resolveFilesToWriter(
+func ResolveFilesToWriter(
 	ctx context.Context,
 	builder *build.Caching,
 	publisher publish.Interface,


### PR DESCRIPTION
this exposes `commands.ResolveFilesToWriter()` to allow downstream consumers to more easily leverage `ko resolve` like functionality through available apis instead of reimplementing it.
