### PR TITLE
update default base image to distroless.dev/static

### DIFF
--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// configDefaultBaseImage is the default base image if not specified in .ko.yaml.
-	configDefaultBaseImage = "ghcr.io/distroless/static:latest"
+	configDefaultBaseImage = "distroless.dev/static:latest"
 )
 
 // BuildOptions represents options for the ko builder.


### PR DESCRIPTION
At this time, `distroless.dev/static` simply redirects to `ghcr.io/distroless/static`, so this is effectively no change since #722.

However, we are evaluating renaming the github.com/distroless org to avoid confusion, and in doing so, images at ghcr.io/distroless may be disrupted. Using the distroless.dev redirector gives us flexibility to change the underlying image registry transparently.

The redirector code for distroless.dev is open source at https://github.com/chainguard-dev/registry-redirect and we've used it extensively internally for a month or two with no serious issues.

Any credentials that are used are not logged or stored by the redirector, and since the image in question is public anyway, any credentials that pass through the redirector have no elevated permissions.