### PR TITLE
Extend ko.local and kind.local detection to include sub-repos

### DIFF
--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -168,7 +168,7 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 	innerPublisher, err := func() (publish.Interface, error) {
 		repoName := po.DockerRepo
 		namer := options.MakeNamer(po)
-		if repoName == publish.LocalDomain || po.Local {
+		if strings.HasPrefix(repoName, publish.LocalDomain) || po.Local {
 			// TODO(jonjohnsonjr): I'm assuming that nobody will
 			// use local with other publishers, but that might
 			// not be true.
@@ -177,7 +177,7 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 				publish.WithLocalDomain(po.LocalDomain),
 			)
 		}
-		if repoName == publish.KindDomain {
+		if strings.HasPrefix(repoName, publish.KindDomain) {
 			return publish.NewKindPublisher(namer, po.Tags), nil
 		}
 


### PR DESCRIPTION
Prior to this, if I set `KO_DOCKER_REPO=kind.local/foo/bar`, this logic would attempt to publish to a remote registry named `kind.local`. Same with `ko.local`.