### PR TITLE
Support --tag and --tag-only with nop publisher

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,6 +33,10 @@ jobs:
         # cribbed from https://gist.github.com/Syeberman/39d81b1e17d091be5657ecd6fbff0753
         eval $(go env | sed -r 's/^(set )?(\w+)=("?)(.*)\3$/\2="\4"/gm')
 
+        # Check that building without push prints the tag (and sha)
+        KO_DOCKER_REPO="" go run ./ build --push=false -t test ./test | grep ":test@sha256:"
+        KO_DOCKER_REPO="" go run ./ build --push=false -t test --tag-only ./test | grep ":test$"
+
         export PLATFORM=${GOOS}/${GOARCH}
 
         if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
@@ -57,10 +61,6 @@ jobs:
         if [[ "$RUNNER_OS" == "Linux" ]]; then
           docker run ${testimg} --wait=false -f b
         fi
-
-        # Check that building without push prints the tag (and sha)
-        KO_DOCKER_REPO="" go run ./ build --push=false -t test ./test | grep ":test@sha256:"
-        KO_DOCKER_REPO="" go run ./ build --push=false -t test --tag-only ./test | grep ":test$"
 
         # Check that using ldflags to set variables works.
         cat > .ko.yaml << EOF

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -59,10 +59,8 @@ jobs:
         fi
 
         # Check that building without push prints the tag (and sha)
-        go run ./ build --push=false -t test ./test
-        go run ./ build --push=false -t test ./test | grep ":test@sha256:"
-        go run ./ build --push=false -t test --tag-only ./test
-        go run ./ build --push=false -t test --tag-only ./test | grep ":test$"
+        KO_DOCKER_REPO="" go run ./ build --push=false -t test ./test | grep ":test@sha256:"
+        KO_DOCKER_REPO="" go run ./ build --push=false -t test --tag-only ./test | grep ":test$"
 
         # Check that using ldflags to set variables works.
         cat > .ko.yaml << EOF

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -58,6 +58,10 @@ jobs:
           docker run ${testimg} --wait=false -f b
         fi
 
+        # Check that building without push prints the tag (and sha)
+        go run ./ build --push=false -t test ./test | grep ":test@sha256:"
+        go run ./ build --push=false -t test --tag-only ./test | grep ":test$"
+
         # Check that using ldflags to set variables works.
         cat > .ko.yaml << EOF
         builds:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,6 +34,7 @@ jobs:
         eval $(go env | sed -r 's/^(set )?(\w+)=("?)(.*)\3$/\2="\4"/gm')
 
         # Check that building without push prints the tag (and sha)
+        KO_DOCKER_REPO="" go run ./ build --push=false ./test | grep ":latest@sha256:"
         KO_DOCKER_REPO="" go run ./ build --push=false -t test ./test | grep ":test@sha256:"
         KO_DOCKER_REPO="" go run ./ build --push=false -t test --tag-only ./test | grep ":test$"
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -59,7 +59,9 @@ jobs:
         fi
 
         # Check that building without push prints the tag (and sha)
+        go run ./ build --push=false -t test ./test
         go run ./ build --push=false -t test ./test | grep ":test@sha256:"
+        go run ./ build --push=false -t test --tag-only ./test
         go run ./ build --push=false -t test --tag-only ./test | grep ":test$"
 
         # Check that using ldflags to set variables works.


### PR DESCRIPTION
Supercedes #689

cc @adambkaplan

With this change, if you use `--push=false` and `-t`, the output ref includes the tag. If you include `--tag-only` the resulting output ref will only include the tag, and _not_ the digest. I'm not sure what purpose that would be useful for, but it's consistent with pushing cases at least.