### PR TITLE
SPDX: Fix package manager label

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ['main']
 
+env:
+  SPDX_TOOLS_VERSION: 1.1.0
+
 jobs:
   go-version-m:
     name: Generate go version -m
@@ -75,15 +78,15 @@ jobs:
 
       - name: Install SPDX Tools
         run: |
-          wget https://github.com/spdx/tools-java/releases/download/v1.0.4/tools-java-1.0.4.zip
-          unzip tools-java-1.0.4.zip
+          wget https://github.com/spdx/tools-java/releases/download/v${SPDX_TOOLS_VERSION}/tools-java-${SPDX_TOOLS_VERSION}.zip
+          unzip tools-java-${SPDX_TOOLS_VERSION}.zip
 
       - name: Generate and Validate
         run: |
           img=$(go run ./ build ./)
           go run ./ deps $img --sbom=spdx | tee spdx.json
 
-          java -jar ./tools-java-1.0.4-jar-with-dependencies.jar Verify spdx.json
+          java -jar ./tools-java-${SPDX_TOOLS_VERSION}-jar-with-dependencies.jar Verify spdx.json
 
       - uses: actions/upload-artifact@v3
         if: ${{ always() }}
@@ -108,8 +111,8 @@ jobs:
 
       - name: Install SPDX Tools
         run: |
-          wget https://github.com/spdx/tools-java/releases/download/v1.0.4/tools-java-1.0.4.zip
-          unzip tools-java-1.0.4.zip
+          wget https://github.com/spdx/tools-java/releases/download/v${SPDX_TOOLS_VERSION}/tools-java-${SPDX_TOOLS_VERSION}.zip
+          unzip tools-java-${SPDX_TOOLS_VERSION}.zip
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v2.5.1
@@ -121,7 +124,7 @@ jobs:
           img=$(go run ./ build --platform=linux/amd64,linux/arm64 ./)
           cosign download sbom $img | tee spdx-multi-arch.json
 
-          java -jar ./tools-java-1.0.4-jar-with-dependencies.jar Verify spdx-multi-arch.json
+          java -jar ./tools-java-${SPDX_TOOLS_VERSION}-jar-with-dependencies.jar Verify spdx-multi-arch.json
 
       - uses: actions/upload-artifact@v3
         if: ${{ always() }}

--- a/internal/sbom/spdx.go
+++ b/internal/sbom/spdx.go
@@ -101,7 +101,7 @@ func GenerateImageSPDX(koVersion string, mod []byte, img oci.SignedImage) ([]byt
 		LicenseDeclared:  NOASSERTION,
 		CopyrightText:    NOASSERTION,
 		ExternalRefs: []ExternalRef{{
-			Category: "PACKAGE_MANAGER",
+			Category: "PACKAGE-MANAGER",
 			Type:     "purl",
 			Locator: ociRef("image", imgDigest, qualifier{
 				key:   "mediaType",
@@ -133,7 +133,7 @@ func GenerateImageSPDX(koVersion string, mod []byte, img oci.SignedImage) ([]byt
 		LicenseDeclared:  NOASSERTION,
 		CopyrightText:    NOASSERTION,
 		ExternalRefs: []ExternalRef{{
-			Category: "PACKAGE_MANAGER",
+			Category: "PACKAGE-MANAGER",
 			Type:     "purl",
 			Locator:  goRef(&bi.Main),
 		}},
@@ -159,7 +159,7 @@ func GenerateImageSPDX(koVersion string, mod []byte, img oci.SignedImage) ([]byt
 			LicenseDeclared:  NOASSERTION,
 			CopyrightText:    NOASSERTION,
 			ExternalRefs: []ExternalRef{{
-				Category: "PACKAGE_MANAGER",
+				Category: "PACKAGE-MANAGER",
 				Type:     "purl",
 				Locator:  goRef(dep),
 			}},
@@ -240,7 +240,7 @@ func GenerateIndexSPDX(koVersion string, sii oci.SignedImageIndex) ([]byte, erro
 			Value:     indexDigest.Hex,
 		}},
 		ExternalRefs: []ExternalRef{{
-			Category: "PACKAGE_MANAGER",
+			Category: "PACKAGE-MANAGER",
 			Type:     "purl",
 			Locator: ociRef("index", indexDigest, qualifier{
 				key:   "mediaType",
@@ -313,7 +313,7 @@ func GenerateIndexSPDX(koVersion string, sii oci.SignedImageIndex) ([]byte, erro
 				LicenseDeclared:  NOASSERTION,
 				CopyrightText:    NOASSERTION,
 				ExternalRefs: []ExternalRef{{
-					Category: "PACKAGE_MANAGER",
+					Category: "PACKAGE-MANAGER",
 					Type:     "purl",
 					Locator:  ociRef("image", imageDigest, qual...),
 				}},
@@ -410,7 +410,7 @@ func addBaseImage(doc *Document, annotations map[string]string, h v1.Hash) error
 		LicenseDeclared:  NOASSERTION,
 		CopyrightText:    NOASSERTION,
 		ExternalRefs: []ExternalRef{{
-			Category: "PACKAGE_MANAGER",
+			Category: "PACKAGE-MANAGER",
 			Type:     "purl",
 			Locator:  ociRef("image", hash, qual...),
 		}},


### PR DESCRIPTION
This commit fixes the package manager label in external references
to make them [conform to the SPDX spec](https://spdx.github.io/spdx-spec/package-information/#721-external-reference-field).

/cc @imjasonh 

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@chainguard.dev>