### PR TITLE
update labelsNode to match new labels interface in kube 1.34

### DIFF
--- a/pkg/resolve/selector.go
+++ b/pkg/resolve/selector.go
@@ -165,3 +165,12 @@ func (n labelsNode) Has(label string) bool {
 	}
 	return false
 }
+
+func (n labelsNode) Lookup(label string) (value string, exists bool) {
+	for i := 0; i < len(n.Content); i += 2 {
+		if n.Content[i].Value == label {
+			return n.Content[i+1].Value, true
+		}
+	}
+	return "", false
+}


### PR DESCRIPTION
Ran into this when pulling ko in as a library:
```
# github.com/google/ko/pkg/resolve
pkg/resolve/selector.go:107:26: cannot use labelsNode{…} (value of struct type labelsNode) as labels.Labels value in argument to selector.Matches: labelsNode does not implement labels.Labels (missing method Lookup)
pkg/resolve/selector.go:149:23: cannot use labelsNode{} (value of struct type labelsNode) as labels.Labels value in variable declaration: labelsNode does not implement labels.Labels (missing method Lookup)
```
I updated the `labelsNode` implementation to match the new interface. I didn't update the apimachinery dependency in this PR; I'm assuming that ko prefers to track released versions only. This should mean that when it's time to update, there are no conflicts.