### PR TITLE
update labelsNode to match new labels interface in kube 1.34

### DIFF
--- a/pkg/resolve/selector.go
+++ b/pkg/resolve/selector.go
@@ -165,3 +165,12 @@ func (n labelsNode) Has(label string) bool {
 	}
 	return false
 }
+
+func (n labelsNode) Lookup(label string) (value string, exists bool) {
+	for i := 0; i < len(n.Content); i += 2 {
+		if n.Content[i].Value == label {
+			return n.Content[i+1].Value, true
+		}
+	}
+	return "", false
+}


### PR DESCRIPTION
Re-opening after the auto-close of #1545 

This change will need to be applied in order for ko to work with kube 1.34+ dependencies. This change is small, completely backwards-compatible, and increases the coverage of the original implementation by adding tests for `labelsNode`.