### PR TITLE
feat: improve push progress output with single-line refresh and transfer rate

### DIFF
--- a/pkg/publish/default.go
+++ b/pkg/publish/default.go
@@ -20,9 +20,11 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"path"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -33,6 +35,7 @@ import (
 	ociremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
 	"github.com/sigstore/cosign/v2/pkg/oci/walk"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/term"
 
 	"github.com/google/ko/pkg/build"
 )
@@ -47,6 +50,7 @@ type defalt struct {
 	jobs     int
 
 	pusher *remote.Pusher
+	ropt   []remote.Option
 	oopt   []ociremote.Option
 }
 
@@ -115,6 +119,7 @@ func (do *defaultOpener) Open() (Interface, error) {
 		insecure: do.insecure,
 		jobs:     do.jobs,
 		pusher:   pusher,
+		ropt:     do.ropt,
 		oopt:     oopt,
 	}, nil
 }
@@ -156,7 +161,7 @@ func (d *defalt) pushResult(ctx context.Context, tag name.Tag, br build.Result) 
 	g.SetLimit(d.jobs)
 
 	g.Go(func() error {
-		return d.pusher.Push(ctx, tag, br)
+		return d.pushWithProgress(ctx, tag, br)
 	})
 
 	// writePeripherals implements walk.Fn
@@ -220,6 +225,139 @@ func (d *defalt) pushResult(ctx context.Context, tag name.Tag, br build.Result) 
 	}
 
 	return g.Wait()
+}
+
+func (d *defalt) pushWithProgress(ctx context.Context, ref name.Reference, target remote.Taggable) error {
+	updates := make(chan v1.Update, 128)
+	options := append([]remote.Option{}, d.ropt...)
+	options = append(options, remote.WithProgress(updates), remote.WithContext(ctx))
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- remote.Push(ref, target, options...)
+	}()
+
+	start := time.Now()
+	lastPrint := start
+	lastComplete := int64(0)
+	total := int64(0)
+	complete := int64(0)
+	var pushErr error
+	updatesOpen := true
+	pushDone := false
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	inlineProgress := term.IsTerminal(int(os.Stderr.Fd()))
+	printedInline := false
+	lastInlineLen := 0
+
+	for updatesOpen || !pushDone {
+		select {
+		case <-ctx.Done():
+			if inlineProgress && printedInline {
+				fmt.Fprintln(os.Stderr)
+			}
+			return ctx.Err()
+		case update, ok := <-updates:
+			if !ok {
+				updatesOpen = false
+				continue
+			}
+			if update.Total > 0 {
+				total = update.Total
+			}
+			if update.Complete > complete {
+				complete = update.Complete
+			}
+		case pushErr = <-errCh:
+			pushDone = true
+		case now := <-ticker.C:
+			if complete == 0 || complete == lastComplete {
+				continue
+			}
+			rate := bytesPerSecond(complete-lastComplete, now.Sub(lastPrint))
+			if inlineProgress {
+				line := progressLineWithRef(inlineRefName(ref), complete, total, rate)
+				lastInlineLen = printInlineProgress(line, lastInlineLen)
+				printedInline = true
+			} else {
+				logProgress(ref, complete, total, rate)
+			}
+			lastComplete = complete
+			lastPrint = now
+		}
+	}
+
+	if complete > 0 || total > 0 {
+		elapsedRate := bytesPerSecond(complete, time.Since(start))
+		if inlineProgress {
+			line := progressLineWithRef(inlineRefName(ref), complete, total, elapsedRate)
+			printInlineProgress(line, lastInlineLen)
+			fmt.Fprintln(os.Stderr)
+		} else {
+			logProgress(ref, complete, total, elapsedRate)
+		}
+	} else if inlineProgress && printedInline {
+		fmt.Fprintln(os.Stderr)
+	}
+	return pushErr
+}
+
+func logProgress(ref name.Reference, complete, total int64, rate float64) {
+	log.Printf("%s", progressLineWithRef(ref.Name(), complete, total, rate))
+}
+
+func progressLineWithRef(refName string, complete, total int64, rate float64) string {
+	if total > 0 {
+		return fmt.Sprintf("Push progress %s: %.1f%% (%s/%s) at %s",
+			refName,
+			100*float64(complete)/float64(total),
+			formatMiB(complete),
+			formatMiB(total),
+			formatRate(rate))
+	}
+	return fmt.Sprintf("Push progress %s: %s uploaded at %s",
+		refName,
+		formatMiB(complete),
+		formatRate(rate))
+}
+
+func printInlineProgress(line string, previousLen int) int {
+	// Use CR + spaces to keep progress on a single line without ANSI reliance.
+	padding := ""
+	if previousLen > len(line) {
+		padding = strings.Repeat(" ", previousLen-len(line))
+	}
+	fmt.Fprintf(os.Stderr, "\r%s%s", line, padding)
+	return len(line)
+}
+
+func inlineRefName(ref name.Reference) string {
+	refName := ref.Name()
+	// Keep inline output short to avoid terminal line wrapping.
+	if slash := strings.LastIndex(refName, "/"); slash >= 0 && slash+1 < len(refName) {
+		refName = refName[slash+1:]
+	}
+	const maxInlineRef = 64
+	if len(refName) > maxInlineRef {
+		refName = "..." + refName[len(refName)-(maxInlineRef-3):]
+	}
+	return refName
+}
+
+func bytesPerSecond(bytes int64, d time.Duration) float64 {
+	if d <= 0 {
+		return 0
+	}
+	return float64(bytes) / d.Seconds()
+}
+
+func formatMiB(bytes int64) string {
+	return fmt.Sprintf("%.2fMiB", float64(bytes)/(1024*1024))
+}
+
+func formatRate(bytesPerSecond float64) string {
+	return fmt.Sprintf("%.2fMiB/s", bytesPerSecond/(1024*1024))
 }
 
 // Publish implements publish.Interface


### PR DESCRIPTION
Testing output:
```sh
2026/03/11 17:52:22 Published SBOM cloudpilotai-registry.cn-hangzhou.cr.aliyuncs.com/cloudpilotai/main.go-4d137a77ea1ba9566690f9ac9bbd03e8:sha256-89f1d7f5d808a2dd1035f8f09c60bc78b89afc9570d982f7985b8e31c194e7d7.sbom
2026/03/11 17:52:22 existing manifest: sha256-85490032a2b49549bb3d61eb1a46db3d66866aaa91b0fb8eb0c5f8aa5fa38783.sbom@sha256:1d1cf158712c3c78487a3d5b16adce505074f5b1c1d608839ce5ee2148ff458c
2026/03/11 17:52:22 Published SBOM cloudpilotai-registry.cn-hangzhou.cr.aliyuncs.com/cloudpilotai/main.go-4d137a77ea1ba9566690f9ac9bbd03e8:sha256-85490032a2b49549bb3d61eb1a46db3d66866aaa91b0fb8eb0c5f8aa5fa38783.sbom
2026/03/11 17:52:22 existing manifest: sha256-da96363cb65133d9f18cd08d46d3637b6a81123770031d9842341fdd461118fe.sbom@sha256:f6b18e270a404820699316c14587066cb204101cae7e75958ec2b3851fe97e67
2026/03/11 17:52:22 Published SBOM cloudpilotai-registry.cn-hangzhou.cr.aliyuncs.com/cloudpilotai/main.go-4d137a77ea1ba9566690f9ac9bbd03e8:sha256-da96363cb65133d9f18cd08d46d3637b6a81123770031d9842341fdd461118fe.sbom
2026/03/11 17:52:22 existing blob: sha256:5d41bdec8ebdce1416d49f873562c4b339775b39850ee7efbb8d91eb448bc85b
2026/03/11 17:52:22 existing blob: sha256:e9f6e7acb3c7f068846b57612052b3adb6b5769989485362c4859c26ea369e94
2026/03/11 17:52:22 existing blob: sha256:250c06f7c38e52dc77e5c7586c3e40280dc7ff9bb9007c396e06d96736cf8542
2026/03/11 17:52:22 existing blob: sha256:d7e0bd31431ce565d0456956f7d3a32cffcb07a1092abe13c3d315286a0be6b6
2026/03/11 17:52:22 existing blob: sha256:f599173ca4d008426b24e6c65c16e36d73213ed75e18f53b3ffadd77b4b69620
Push progress main.go-4d137a77ea1ba9566690f9ac9bbd03e8:latest: 27.3% (33.22MiB/121.55MiB) at 0.13MiB/s
```