### PR TITLE
fix: correct --sbom-dir flag description (file → directory)

### DIFF
--- a/docs/reference/ko_apply.md
+++ b/docs/reference/ko_apply.md
@@ -64,7 +64,7 @@ ko apply -f FILENAME [flags]
       --push                       Push images to KO_DOCKER_REPO (default true)
   -R, --recursive                  Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
       --sbom string                The SBOM media type to use (none will disable SBOM synthesis and upload). (default "spdx")
-      --sbom-dir string            Path to file where the SBOM will be written.
+      --sbom-dir string            Path to directory where the SBOM will be written.
   -l, --selector string            Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
       --tag-only                   Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings               Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])

--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -59,7 +59,7 @@ ko build IMPORTPATH... [flags]
   -P, --preserve-import-paths      Whether to preserve the full import path after KO_DOCKER_REPO.
       --push                       Push images to KO_DOCKER_REPO (default true)
       --sbom string                The SBOM media type to use (none will disable SBOM synthesis and upload). (default "spdx")
-      --sbom-dir string            Path to file where the SBOM will be written.
+      --sbom-dir string            Path to directory where the SBOM will be written.
       --tag-only                   Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings               Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
       --tarball string             File to save images tarballs

--- a/docs/reference/ko_create.md
+++ b/docs/reference/ko_create.md
@@ -64,7 +64,7 @@ ko create -f FILENAME [flags]
       --push                       Push images to KO_DOCKER_REPO (default true)
   -R, --recursive                  Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
       --sbom string                The SBOM media type to use (none will disable SBOM synthesis and upload). (default "spdx")
-      --sbom-dir string            Path to file where the SBOM will be written.
+      --sbom-dir string            Path to directory where the SBOM will be written.
   -l, --selector string            Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
       --tag-only                   Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings               Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])

--- a/docs/reference/ko_resolve.md
+++ b/docs/reference/ko_resolve.md
@@ -57,7 +57,7 @@ ko resolve -f FILENAME [flags]
       --push                       Push images to KO_DOCKER_REPO (default true)
   -R, --recursive                  Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
       --sbom string                The SBOM media type to use (none will disable SBOM synthesis and upload). (default "spdx")
-      --sbom-dir string            Path to file where the SBOM will be written.
+      --sbom-dir string            Path to directory where the SBOM will be written.
   -l, --selector string            Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
       --tag-only                   Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings               Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])

--- a/docs/reference/ko_run.md
+++ b/docs/reference/ko_run.md
@@ -47,7 +47,7 @@ ko run IMPORTPATH [flags]
   -P, --preserve-import-paths      Whether to preserve the full import path after KO_DOCKER_REPO.
       --push                       Push images to KO_DOCKER_REPO (default true)
       --sbom string                The SBOM media type to use (none will disable SBOM synthesis and upload). (default "spdx")
-      --sbom-dir string            Path to file where the SBOM will be written.
+      --sbom-dir string            Path to directory where the SBOM will be written.
       --tag-only                   Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings               Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
       --tarball string             File to save images tarballs

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -92,7 +92,7 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 	cmd.Flags().StringVar(&bo.SBOM, "sbom", "spdx",
 		"The SBOM media type to use (none will disable SBOM synthesis and upload).")
 	cmd.Flags().StringVar(&bo.SBOMDir, "sbom-dir", "",
-		"Path to file where the SBOM will be written.")
+		"Path to directory where the SBOM will be written.")
 	cmd.Flags().StringSliceVar(&bo.Platforms, "platform", []string{},
 		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*")
 	cmd.Flags().StringSliceVar(&bo.Labels, "image-label", []string{},


### PR DESCRIPTION
`--sbom-dir` has been described as "Path to file where the SBOM will be written." since it landed in #822 — but the flag is clearly a directory, not a file.

**How to reproduce:**

```
ko build --help | grep sbom-dir
# Path to file where the SBOM will be written.  ← wrong
```

The impl literally does `os.MkdirAll` on the value and then drops files *inside* it:

```go
// pkg/build/gobuild.go
sbomDir := filepath.Clean(dir)
os.MkdirAll(sbomDir, os.ModePerm)          // creates a dir
sbomPath := filepath.Join(sbomDir, ...)    // writes file inside it
```

Even the field is named `SBOMDir` and the flag is `--sbom-dir` lol.

**Fix:** one-word change in the flag description (`file` → `directory`) + regenerated docs via `./hack/update-codegen.sh`. No behavior change.

`./hack/presubmit.sh` passes.