### PR TITLE
Fix golangci-lint v2.12.2 gosec and prealloc findings

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -48,4 +48,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.4.0
         with:
-          version: v2.7.2
+          version: v2.12.2

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -374,11 +374,15 @@ func build(ctx context.Context, buildCtx buildContext) (string, error) {
 	tmpDir := ""
 
 	if dir := os.Getenv("KOCACHE"); dir != "" {
+		// KOCACHE is a user-supplied cache directory; clean it before use.
+		dir = filepath.Clean(dir)
+		/* #nosec G304 G703 -- KOCACHE is intentionally user-controlled. */
 		dirInfo, err := os.Stat(dir)
 		if err != nil {
 			if !os.IsNotExist(err) {
 				return "", fmt.Errorf("could not stat KOCACHE: %w", err)
 			}
+			/* #nosec G304 G703 -- KOCACHE is intentionally user-controlled. */
 			if err := os.MkdirAll(dir, os.ModePerm); err != nil && !os.IsExist(err) {
 				return "", fmt.Errorf("could not create KOCACHE dir %s: %w", dir, err)
 			}
@@ -388,6 +392,7 @@ func build(ctx context.Context, buildCtx buildContext) (string, error) {
 
 		// TODO(#264): if KOCACHE is unset, default to filepath.Join(os.TempDir(), "ko").
 		tmpDir = filepath.Join(dir, "bin", buildCtx.ip, buildCtx.platform.String())
+		/* #nosec G304 G703 -- tmpDir is derived from the user-controlled KOCACHE. */
 		if err := os.MkdirAll(tmpDir, os.ModePerm); err != nil {
 			return "", fmt.Errorf("creating KOCACHE bin dir: %w", err)
 		}
@@ -404,6 +409,7 @@ func build(ctx context.Context, buildCtx buildContext) (string, error) {
 	args = append(args, buildCtx.ip)
 
 	gobin := getGoBinary()
+	/* #nosec G204 G702 -- ko intentionally invokes the user-configured go toolchain with user-supplied build args. */
 	cmd := exec.CommandContext(ctx, gobin, args...)
 	cmd.Dir = buildCtx.dir
 	cmd.Env = buildCtx.env

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -121,6 +121,7 @@ func (bo *BuildOptions) LoadConfig() error {
 	v.AutomaticEnv()
 
 	if override := os.Getenv("KO_CONFIG_PATH"); override != "" {
+		/* #nosec G304 G703 -- KO_CONFIG_PATH is intentionally user-controlled. */
 		file, err := os.Stat(override)
 		if err != nil {
 			return fmt.Errorf("error looking for config file: %w", err)
@@ -129,6 +130,7 @@ func (bo *BuildOptions) LoadConfig() error {
 			v.SetConfigFile(override)
 		} else if file.IsDir() {
 			path := filepath.Join(override, ".ko.yaml")
+			/* #nosec G304 G703 -- path is derived from the user-controlled KO_CONFIG_PATH. */
 			file, err = os.Stat(path)
 			if err != nil {
 				return fmt.Errorf("error looking for config file: %w", err)

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -121,7 +121,9 @@ func addRun(topLevel *cobra.Command) {
 				// "run <package> <defaults> --image <ref> <kubectlArgs>"
 				argv = append([]string{"run", pod}, argv...)
 
+				/* #nosec G706 -- argv is the kubectl invocation we just built; logging it is the intent. */
 				log.Printf("$ kubectl %s", strings.Join(argv, " "))
+				/* #nosec G204 G702 -- ko run intentionally invokes kubectl with user-supplied arguments. */
 				kubectlCmd := exec.CommandContext(ctx, "kubectl", argv...)
 
 				// Pass through our environment

--- a/pkg/internal/git/git.go
+++ b/pkg/internal/git/git.go
@@ -52,9 +52,8 @@ type runConfig struct {
 
 // run a git command and returns its output or errors.
 func run(ctx context.Context, cfg runConfig) (string, error) {
-	extraArgs := []string{
-		"-c", "log.showSignature=false",
-	}
+	extraArgs := make([]string, 0, 2+len(cfg.args))
+	extraArgs = append(extraArgs, "-c", "log.showSignature=false")
 	cfg.args = append(extraArgs, cfg.args...)
 	/* #nosec */
 	cmd := exec.CommandContext(ctx, "git", cfg.args...)

--- a/pkg/internal/git/info.go
+++ b/pkg/internal/git/info.go
@@ -201,12 +201,8 @@ func getTag(ctx context.Context, dir string, excluding []string) (string, error)
 }
 
 func gitDescribe(ctx context.Context, dir, ref string, excluding []string) (string, error) {
-	args := []string{
-		"describe",
-		"--tags",
-		"--abbrev=0",
-		ref,
-	}
+	args := make([]string, 0, 4+len(excluding))
+	args = append(args, "describe", "--tags", "--abbrev=0", ref)
 	for _, exclude := range excluding {
 		args = append(args, "--exclude="+exclude)
 	}

--- a/pkg/internal/gittesting/git.go
+++ b/pkg/internal/gittesting/git.go
@@ -89,13 +89,14 @@ func GitAdd(t *testing.T, dir string) {
 }
 
 func fakeGit(dir string, args ...string) (string, error) {
-	allArgs := []string{
+	allArgs := make([]string, 0, 10+len(args))
+	allArgs = append(allArgs,
 		"-c", "user.name='GoReleaser'",
 		"-c", "user.email='test@goreleaser.github.com'",
 		"-c", "commit.gpgSign=false",
 		"-c", "tag.gpgSign=false",
 		"-c", "log.showSignature=false",
-	}
+	)
 	allArgs = append(allArgs, args...)
 	return gitRun(dir, allArgs...)
 }


### PR DESCRIPTION
Address findings from the latest golangci-lint:

- prealloc: preallocate the args/extraArgs/allArgs slices with the
  capacity they will eventually hold in pkg/internal/git/git.go,
  pkg/internal/git/info.go, and pkg/internal/gittesting/git.go.
- gosec G703/G304: KOCACHE and KO_CONFIG_PATH are user-supplied paths
  by design. Clean the KOCACHE value with filepath.Clean and annotate
  the os.Stat/os.MkdirAll call sites with #nosec, matching the existing
  pattern from pkg/internal/git/git.go.
- gosec G702/G204: invoking the configured go toolchain and kubectl
  with user-supplied build/run arguments is the intended behaviour of
  ko build and ko run; annotate the exec.CommandContext call sites
  with #nosec accordingly.
- gosec G706: logging the kubectl command line that ko is about to
  execute is the entire point of the log line; annotate with #nosec.