### PR TITLE
fix: check error return from yaml.Encoder.Close() in resolveFile

### DIFF
--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -477,7 +477,9 @@ func resolveFile(
 			return nil, fmt.Errorf("failed to encode output: %w", err)
 		}
 	}
-	e.Close()
+	if err := e.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close yaml encoder: %w", err)
+	}
 
 	return buf.Bytes(), nil
 }


### PR DESCRIPTION
`resolveFile()` in `pkg/commands/resolver.go` calls `yaml.Encoder.Close()` without checking its error return value. The `Close()` method flushes remaining buffered data and can fail; discarding the error means the function may return incomplete YAML to callers without any error indication.

This change checks the error from `Close()` and propagates it, consistent with how `Encode()` errors are already handled in the same function.
