### PR TITLE
update ./test to demonstrate multiple ldflags via GOFLAGS

### DIFF
--- a/docs/advanced/faq.md
+++ b/docs/advanced/faq.md
@@ -6,12 +6,10 @@
 Unfortunately, because `ko` wraps `go build`, it's not possible to use this flag directly; however, you can use the `GOFLAGS` environment variable instead:
 
 ```sh
-GOFLAGS="-ldflags=-X=main.version=1.2.3" ko build .
+GOFLAGS="-ldflags=-X=main.version=1.2.3 -ldflags=-X=main.foo=bar" ko build .
 ```
 
-Currently, there is a limitation that does not allow to set multiple arguments in `ldflags` using `GOFLAGS`.
-Using `-ldflags` multiple times also does not work.
-In this use case, it works best to use the [`builds` section](./../configuration.md) in the `.ko.yaml` file.
+You can also set `-ldflags` using the [`builds` section](./../configuration.md) in the `.ko.yaml` file.
 
 ## Why are my images all created in 1970?
 

--- a/test/main.go
+++ b/test/main.go
@@ -34,13 +34,17 @@ var (
 	wait = flag.Bool("wait", false, "Whether to wait for SIGTERM")
 )
 
-// This is defined so we can test build-time variable setting using ldflags.
-var version = "default"
+// These are defined so we can test build-time variable setting using ldflags.
+var (
+	version      = "default"
+	anotherThing = "anotherThing"
+)
 
 func main() {
 	flag.Parse()
 
 	log.Println("version =", version)
+	log.Println("anotherThing =", anotherThing)
 
 	if runtime.GOOS == "windows" {
 		// Go seems to not load location data from Windows, so timezone


### PR DESCRIPTION
```
$ docker run --rm $(GOFLAGS="-ldflags=-X=main.version=foo -ldflags=-X=main.anotherThing=blah" ko build --local ./test)
...
2026/06/03 16:42:14 version = default
2026/06/03 16:42:14 anotherThing = blah
```

I'm not sure why the docs say you can't do this, so I updated them.

edit: bah crap this actually demonstrates the issue 👎 