### PR TITLE
Add repeatable --ldflags flag for go build

### DIFF
--- a/docs/advanced/faq.md
+++ b/docs/advanced/faq.md
@@ -3,15 +3,20 @@
 ## How can I set `ldflags`?
 
 [Using -ldflags](https://blog.cloudflare.com/setting-go-variables-at-compile-time/) is a common way to embed version info in go binaries (In fact, we do this for `ko`!).
-Unfortunately, because `ko` wraps `go build`, it's not possible to use this flag directly; however, you can use the `GOFLAGS` environment variable instead:
+You can pass ldflags to `go build` with the `--ldflags` flag (repeatable):
+
+```sh
+ko build --ldflags "-X=main.version=1.2.3" --ldflags "-s -w" .
+```
+
+You can also use the `GOFLAGS` environment variable:
 
 ```sh
 GOFLAGS="-ldflags=-X=main.version=1.2.3" ko build .
 ```
 
-Currently, there is a limitation that does not allow to set multiple arguments in `ldflags` using `GOFLAGS`.
-Using `-ldflags` multiple times also does not work.
-In this use case, it works best to use the [`builds` section](./../configuration.md) in the `.ko.yaml` file.
+`GOFLAGS` has a limitation that does not allow setting multiple arguments in `ldflags`.
+For more complex cases, use the [`builds` section](./../configuration.md) in the `.ko.yaml` file.
 
 ## Why are my images all created in 1970?
 

--- a/docs/advanced/faq.md
+++ b/docs/advanced/faq.md
@@ -3,7 +3,7 @@
 ## How can I set `ldflags`?
 
 [Using -ldflags](https://blog.cloudflare.com/setting-go-variables-at-compile-time/) is a common way to embed version info in go binaries (In fact, we do this for `ko`!).
-You can pass ldflags to `go build` with the `--ldflags` flag (repeatable):
+You can pass ldflags to `go build` with the `--ldflags` flag (repeatable). When set, `--ldflags` takes precedence over ldflags in `.ko.yaml`:
 
 ```sh
 ko build --ldflags "-X=main.version=1.2.3" --ldflags "-s -w" .

--- a/docs/reference/ko_apply.md
+++ b/docs/reference/ko_apply.md
@@ -57,6 +57,7 @@ ko apply -f FILENAME [flags]
       --image-user string          The default user the image should be run as.
       --insecure-registry          Whether to skip TLS verification on the registry
   -j, --jobs int                   The maximum number of concurrent builds (default GOMAXPROCS)
+      --ldflags strings            ldflags to pass to go build (may be repeated)
   -L, --local                      Load into images to local docker daemon.
       --oci-layout-path string     Path to save the OCI image layout of the built images
       --platform strings           Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*

--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -53,6 +53,7 @@ ko build IMPORTPATH... [flags]
       --image-user string          The default user the image should be run as.
       --insecure-registry          Whether to skip TLS verification on the registry
   -j, --jobs int                   The maximum number of concurrent builds (default GOMAXPROCS)
+      --ldflags strings            ldflags to pass to go build (may be repeated)
   -L, --local                      Load into images to local docker daemon.
       --oci-layout-path string     Path to save the OCI image layout of the built images
       --platform strings           Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*

--- a/docs/reference/ko_create.md
+++ b/docs/reference/ko_create.md
@@ -57,6 +57,7 @@ ko create -f FILENAME [flags]
       --image-user string          The default user the image should be run as.
       --insecure-registry          Whether to skip TLS verification on the registry
   -j, --jobs int                   The maximum number of concurrent builds (default GOMAXPROCS)
+      --ldflags strings            ldflags to pass to go build (may be repeated)
   -L, --local                      Load into images to local docker daemon.
       --oci-layout-path string     Path to save the OCI image layout of the built images
       --platform strings           Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*

--- a/docs/reference/ko_resolve.md
+++ b/docs/reference/ko_resolve.md
@@ -50,6 +50,7 @@ ko resolve -f FILENAME [flags]
       --image-user string          The default user the image should be run as.
       --insecure-registry          Whether to skip TLS verification on the registry
   -j, --jobs int                   The maximum number of concurrent builds (default GOMAXPROCS)
+      --ldflags strings            ldflags to pass to go build (may be repeated)
   -L, --local                      Load into images to local docker daemon.
       --oci-layout-path string     Path to save the OCI image layout of the built images
       --platform strings           Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*

--- a/docs/reference/ko_run.md
+++ b/docs/reference/ko_run.md
@@ -41,6 +41,7 @@ ko run IMPORTPATH [flags]
       --image-user string          The default user the image should be run as.
       --insecure-registry          Whether to skip TLS verification on the registry
   -j, --jobs int                   The maximum number of concurrent builds (default GOMAXPROCS)
+      --ldflags strings            ldflags to pass to go build (may be repeated)
   -L, --local                      Load into images to local docker daemon.
       --oci-layout-path string     Path to save the OCI image layout of the built images
       --platform strings           Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -99,6 +99,7 @@ type gobuild struct {
 	defaultEnv           []string
 	defaultFlags         []string
 	defaultLdflags       []string
+	ldflags              []string
 	platformMatcher      *platformMatcher
 	dir                  string
 	labels               map[string]string
@@ -127,6 +128,7 @@ type gobuildOpener struct {
 	defaultEnv           []string
 	defaultFlags         []string
 	defaultLdflags       []string
+	ldflags              []string
 	platforms            []string
 	labels               map[string]string
 	annotations          map[string]string
@@ -165,6 +167,7 @@ func (gbo *gobuildOpener) Open() (Interface, error) {
 		defaultEnv:           gbo.defaultEnv,
 		defaultFlags:         gbo.defaultFlags,
 		defaultLdflags:       gbo.defaultLdflags,
+		ldflags:              gbo.ldflags,
 		labels:               gbo.labels,
 		annotations:          gbo.annotations,
 		dir:                  gbo.dir,
@@ -1083,11 +1086,13 @@ func (g *gobuild) buildOne(ctx context.Context, refStr string, base v1.Image, pl
 	// Get the build flags (defaultFlags already applied in configForImportPath).
 	flags := config.Flags
 
-	// Get the build ldflags.
-	ldflags := config.Ldflags
+	// Get the build ldflags. CLI ldflags override .ko.yaml per-build and default ldflags.
+	ldflags := g.ldflags
 	if len(ldflags) == 0 {
-		// Use the default, if any
-		ldflags = g.defaultLdflags
+		ldflags = config.Ldflags
+		if len(ldflags) == 0 {
+			ldflags = g.defaultLdflags
+		}
 	}
 
 	// Do the build into a temporary file.

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -1109,6 +1109,40 @@ func TestGoBuild_Defaults(t *testing.T) {
 	require.Equal(t, "bar", envVars["BAR"])
 }
 
+func TestGoBuild_CLILdflagsOverrideConfig(t *testing.T) {
+	baseLayers := int64(3)
+	base, err := random.Image(1024, baseLayers)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+	importpath := "github.com/google/ko"
+
+	var buildCtx buildContext
+	ng, err := NewGo(
+		context.Background(),
+		"",
+		WithBaseImages(func(context.Context, string) (name.Reference, Result, error) { return baseRef, base, nil }),
+		withBuilder(func(_ context.Context, b buildContext) (string, error) {
+			buildCtx = b
+			return "", errors.New("fake build error")
+		}),
+		withSBOMber(fauxSBOM),
+		WithPlatforms("all"),
+		WithDefaultLdflags([]string{"-s"}),
+		WithLdflags([]string{"-X=main.version=cli"}),
+		WithConfig(map[string]Config{
+			"github.com/google/ko/test": {
+				Ldflags: StringArray{"-w"},
+			},
+		}),
+	)
+	require.NoError(t, err)
+
+	_, err = ng.Build(context.Background(), StrictScheme+filepath.Join(importpath, "test"))
+	require.ErrorContains(t, err, "fake build error")
+	require.Equal(t, []string{"-X=main.version=cli"}, buildCtx.ldflags)
+}
+
 func TestGoBuild_ConfigOverrideDefaults(t *testing.T) {
 	baseLayers := int64(3)
 	base, err := random.Image(1024, baseLayers)

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -110,6 +110,15 @@ func WithDefaultLdflags(ldflags []string) Option {
 	}
 }
 
+// WithLdflags is a functional option for ldflags passed via the CLI. When set,
+// these take precedence over ldflags from .ko.yaml.
+func WithLdflags(ldflags []string) Option {
+	return func(gbo *gobuildOpener) error {
+		gbo.ldflags = ldflags
+		return nil
+	}
+}
+
 // WithPlatforms is a functional option for building certain platforms for
 // multi-platform base images. To build everything from the base, use "all",
 // otherwise use a list of platform specs, i.e.:

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -59,6 +59,10 @@ type BuildOptions struct {
 	// Empty string means the current working directory.
 	WorkingDirectory string
 
+	// Ldflags are ldflags passed to go build via the CLI. When set, these take
+	// precedence over defaultLdflags from .ko.yaml.
+	Ldflags []string
+
 	ConcurrentBuilds     int
 	DisableOptimizations bool
 	SBOM                 string
@@ -89,6 +93,8 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"The maximum number of concurrent builds (default GOMAXPROCS)")
 	cmd.Flags().BoolVar(&bo.DisableOptimizations, "disable-optimizations", bo.DisableOptimizations,
 		"Disable optimizations when building Go code. Useful when you want to interactively debug the created container.")
+	cmd.Flags().StringSliceVar(&bo.Ldflags, "ldflags", nil,
+		"ldflags to pass to go build (may be repeated)")
 	cmd.Flags().StringVar(&bo.SBOM, "sbom", "spdx",
 		"The SBOM media type to use (none will disable SBOM synthesis and upload).")
 	cmd.Flags().StringVar(&bo.SBOMDir, "sbom-dir", "",

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -60,7 +60,7 @@ type BuildOptions struct {
 	WorkingDirectory string
 
 	// Ldflags are ldflags passed to go build via the CLI. When set, these take
-	// precedence over defaultLdflags from .ko.yaml.
+	// precedence over ldflags from .ko.yaml.
 	Ldflags []string
 
 	ConcurrentBuilds     int

--- a/pkg/commands/options/build_test.go
+++ b/pkg/commands/options/build_test.go
@@ -148,6 +148,20 @@ func TestCreateBuildConfigs(t *testing.T) {
 	}
 }
 
+func TestLdflagsFlag(t *testing.T) {
+	cmd := &cobra.Command{}
+	bo := &BuildOptions{}
+	AddBuildOptions(cmd, bo)
+
+	err := cmd.ParseFlags([]string{
+		"--ldflags", "-X=main.version=1.2.3",
+		"--ldflags", "-s",
+		"--ldflags", "-w",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"-X=main.version=1.2.3", "-s", "-w"}, bo.Ldflags)
+}
+
 func TestAddBuildOptionsSetsDefaultsForNonFlagOptions(t *testing.T) {
 	cmd := &cobra.Command{}
 	bo := &BuildOptions{}

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -84,16 +84,11 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 		}
 	}
 
-	defaultLdflags := bo.DefaultLdflags
-	if len(bo.Ldflags) > 0 {
-		defaultLdflags = bo.Ldflags
-	}
-
 	opts := []build.Option{
 		build.WithBaseImages(getBaseImage(bo)),
 		build.WithDefaultEnv(bo.DefaultEnv),
 		build.WithDefaultFlags(bo.DefaultFlags),
-		build.WithDefaultLdflags(defaultLdflags),
+		build.WithDefaultLdflags(bo.DefaultLdflags),
 		build.WithPlatforms(bo.Platforms...),
 		build.WithJobs(bo.ConcurrentBuilds),
 	}
@@ -102,6 +97,9 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 	}
 	if kodataCreationTime != nil {
 		opts = append(opts, build.WithKoDataCreationTime(*kodataCreationTime))
+	}
+	if len(bo.Ldflags) > 0 {
+		opts = append(opts, build.WithLdflags(bo.Ldflags))
 	}
 	if bo.DisableOptimizations {
 		opts = append(opts, build.WithDisabledOptimizations())

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -84,11 +84,16 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 		}
 	}
 
+	defaultLdflags := bo.DefaultLdflags
+	if len(bo.Ldflags) > 0 {
+		defaultLdflags = bo.Ldflags
+	}
+
 	opts := []build.Option{
 		build.WithBaseImages(getBaseImage(bo)),
 		build.WithDefaultEnv(bo.DefaultEnv),
 		build.WithDefaultFlags(bo.DefaultFlags),
-		build.WithDefaultLdflags(bo.DefaultLdflags),
+		build.WithDefaultLdflags(defaultLdflags),
 		build.WithPlatforms(bo.Platforms...),
 		build.WithJobs(bo.ConcurrentBuilds),
 	}


### PR DESCRIPTION
Adds a `--ldflags` CLI flag (repeatable) to pass linker flags to `go build` when building container images.

https://github.com/ko-build/ko/issues/1675

## Behavior

- Available on all commands that share `BuildOptions` (`build`, `apply`, `resolve`, `create`, `run`, etc.).
- Repeated values are joined and passed as a single `-ldflags` argument to `go build`.
- When set, `--ldflags` takes precedence over ldflags in `.ko.yaml` (both `defaultLdflags` and per-build `builds[].ldflags`).
- `GOFLAGS` continues to work when `--ldflags` is not set.

## Example

```sh
ko build --ldflags "-X=main.version=1.2.3" --ldflags "-s -w" .
```