### PR TITLE
fix: skip yaml encoding when selector filters all documents

### DIFF
--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -470,6 +470,13 @@ func resolveFile(
 		return nil, fmt.Errorf("error resolving image references: %w", err)
 	}
 
+	// If the selector filtered out all documents, skip encoding entirely.
+	// Calling Close() on an encoder that never wrote anything causes
+	// go.yaml.in/yaml/v4 to return "yaml: expected STREAM-START".
+	if len(docNodes) == 0 {
+		return []byte{}, nil
+	}
+
 	buf := &bytes.Buffer{}
 	e := yaml.NewEncoder(buf)
 	e.SetIndent(2)


### PR DESCRIPTION
When a label selector filters out all documents in a YAML file, docNodes is empty and the encode loop is never entered. Calling Close() on an encoder that never wrote anything causes go.yaml.in/yaml/v4 to return "yaml: expected STREAM-START", which was silently ignored in v0.18.x (error was discarded) but is now propagated as a fatal error.

Return early with empty bytes when docNodes is empty to avoid invoking the encoder at all.

Fixes: `failed to close yaml encoder: yaml: expected STREAM-START` when using ko resolve with a label selector that excludes all resources in a file.

Fixes #1693 