### PR TITLE
Handle a descriptor without a platform when building an index SBOM

### DIFF
--- a/internal/sbom/spdx.go
+++ b/internal/sbom/spdx.go
@@ -292,36 +292,41 @@ func GenerateIndexSPDX(koVersion string, sii oci.SignedImageIndex) ([]byte, erro
 			qual := []qualifier{{
 				key:   "mediaType",
 				value: string(desc.MediaType),
-			}, {
-				key:   "arch",
-				value: desc.Platform.Architecture,
-			}, {
-				key:   "os",
-				value: desc.Platform.OS,
 			}}
-			if desc.Platform.Variant != "" {
+			// platform is optional on an index descriptor, so a base index can
+			// legitimately hold a manifest without one.
+			if p := desc.Platform; p != nil {
 				qual = append(qual, qualifier{
-					key:   "variant",
-					value: desc.Platform.Variant,
+					key:   "arch",
+					value: p.Architecture,
+				}, qualifier{
+					key:   "os",
+					value: p.OS,
 				})
-			}
-			if desc.Platform.OSVersion != "" {
-				qual = append(qual, qualifier{
-					key:   "os-version",
-					value: desc.Platform.OSVersion,
-				})
-			}
-			for _, feat := range desc.Platform.OSFeatures {
-				qual = append(qual, qualifier{
-					key:   "os-feature",
-					value: feat,
-				})
+				if p.Variant != "" {
+					qual = append(qual, qualifier{
+						key:   "variant",
+						value: p.Variant,
+					})
+				}
+				if p.OSVersion != "" {
+					qual = append(qual, qualifier{
+						key:   "os-version",
+						value: p.OSVersion,
+					})
+				}
+				for _, feat := range p.OSFeatures {
+					qual = append(qual, qualifier{
+						key:   "os-feature",
+						value: feat,
+					})
+				}
 			}
 
 			doc.Packages = append(doc.Packages, Package{
 				ID:      depID,
 				Name:    imageDigest.String(),
-				Version: desc.Platform.String(),
+				Version: platformVersion(desc.Platform),
 				// TODO: PackageSupplier: "Organization: " + dep.Path
 				DownloadLocation: NOASSERTION,
 				FilesAnalyzed:    false,
@@ -541,4 +546,13 @@ type ExternalDocumentRef struct {
 	Checksum           Checksum `json:"checksum"`
 	ExternalDocumentID string   `json:"externalDocumentId"`
 	SPDXDocument       string   `json:"spdxDocument"`
+}
+
+// platformVersion renders a descriptor's platform, which the image index spec
+// leaves optional, so it may be absent.
+func platformVersion(p *v1.Platform) string {
+	if p == nil {
+		return ""
+	}
+	return p.String()
 }

--- a/internal/sbom/spdx_test.go
+++ b/internal/sbom/spdx_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 ko Build Authors All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sbom
+
+import (
+	"strings"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sigstore/cosign/v3/pkg/oci/signed"
+)
+
+// A base index can carry a manifest with no platform, which the image index
+// spec allows, and ko copies that descriptor through to the index it builds.
+func TestGenerateIndexSPDXWithoutPlatform(t *testing.T) {
+	img, err := random.Image(4, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	idx := mutate.IndexMediaType(empty.Index, types.OCIImageIndex)
+	idx = mutate.AppendManifests(idx,
+		mutate.IndexAddendum{
+			Add:        img,
+			Descriptor: v1.Descriptor{Platform: &v1.Platform{OS: "linux", Architecture: "amd64"}},
+		},
+		mutate.IndexAddendum{
+			Add: img,
+		},
+	)
+
+	im, err := idx.IndexManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if im.Manifests[1].Platform != nil {
+		t.Fatalf("expected the second manifest to have no platform, got %v", im.Manifests[1].Platform)
+	}
+
+	b, err := GenerateIndexSPDX("v0.0.0-test", signed.ImageIndex(idx))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(b) == 0 {
+		t.Fatal("expected an SBOM, got nothing")
+	}
+	if !strings.Contains(string(b), "linux") {
+		t.Error("expected the platform of the described manifest to survive")
+	}
+}


### PR DESCRIPTION
`GenerateIndexSPDX` walks the manifests of the index it just built and reads the platform of each one:

```go
value: desc.Platform.Architecture,
...
Version: desc.Platform.String(),
```

`platform` is optional on an index descriptor in the image index spec, and `v1.Descriptor.Platform` is a pointer, so those are nil dereferences for an entry that omits it.

That is reachable through a normal build. With `--platform=all`, `matches()` in `pkg/build/gobuild.go` short circuits on `all` before the platform is examined, so a base index entry with no platform is accepted; `buildAll` copies `Platform: desc.Platform` verbatim, and go-containerregistry preserves the nil through `AppendManifests`. SBOM generation is on by default (`--sbom=spdx`), so the panic lands at the end of an otherwise successful build.

The qualifiers now only include arch, os, variant, os-version and os-feature when a platform is present, and the package version renders as an empty string rather than calling `String()` on nil. A platform-less entry still gets its package and relationship in the document, just without platform qualifiers, which seemed better than dropping it from the SBOM entirely.

Test builds an index with one linux/amd64 entry and one addendum with no descriptor platform, asserts go-containerregistry really does keep the nil, and then generates the SBOM. It panics on main and passes with the change. `go test ./internal/...` is green and `go vet ./internal/sbom/` is clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized SBOM generation fix with a regression test; no auth, build, or publish behavior changes beyond avoiding a crash.
> 
> **Overview**
> Fixes a **panic** at the end of multi-platform builds when default SPDX SBOM generation walks an index entry whose manifest descriptor has no `platform` (allowed by the OCI image index spec and reachable via `--platform=all`).
> 
> `GenerateIndexSPDX` no longer dereferences `desc.Platform` unconditionally: arch/os/variant/os-version/os-feature pURL qualifiers are added only when a platform is present, and package version uses a new `platformVersion` helper that returns an empty string instead of calling `String()` on nil. Platform-less manifests still appear in the SBOM with `mediaType` only.
> 
> Adds `TestGenerateIndexSPDXWithoutPlatform` with a mixed index (one `linux/amd64` entry and one manifest with no platform).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a35033367d74610ac65d2101a1e3454d8629503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->